### PR TITLE
feat!: futher IBC power shift safeguards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,14 @@ export GO111MODULE = on
 ###   Testing   ####
 ####################
 
+include e2e/Makefile
+
 test:
 	@echo "--> Running tests"
 	go test -v ./...
 
-test-integration:
-	@echo "--> Running integration tests"
-	cd integration; go test -v ./...
-
 ictest-poa:
-	cd e2e && go clean -testcache && go test -race -v -run TestPOA .
+	$(MAKE) -C e2e/ ictest-poa
 
 ###############################################################################
 ###                                  Docker                                 ###

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -1,0 +1,2 @@
+ictest-poa:
+	go clean -testcache && go test -race -v -run TestPOA .

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/strangelove-ventures/interchaintest/v8 v8.0.0
 	github.com/strangelove-ventures/poa v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/sync v0.5.0
 )
 
 require (
@@ -70,7 +69,7 @@ require (
 	github.com/cockroachdb/pebble v0.0.0-20231101195458-481da04154d6 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
-	github.com/cometbft/cometbft v0.38.0 // indirect
+	github.com/cometbft/cometbft v0.38.1 // indirect
 	github.com/cometbft/cometbft-db v0.8.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-db v1.0.0 // indirect
@@ -231,6 +230,7 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -355,8 +355,8 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/cometbft/cometbft v0.38.0 h1:ogKnpiPX7gxCvqTEF4ly25/wAxUqf181t30P3vqdpdc=
-github.com/cometbft/cometbft v0.38.0/go.mod h1:5Jz0Z8YsHSf0ZaAqGvi/ifioSdVFPtEGrm8Y9T/993k=
+github.com/cometbft/cometbft v0.38.1 h1:hflfGk/VrPapfHco3rgCqn2YpOglAqJshSdyrM2zSLk=
+github.com/cometbft/cometbft v0.38.1/go.mod h1:PIi48BpzwlHqtV3mzwPyQgOyOnU94BNBimLS2ebBHOg=
 github.com/cometbft/cometbft-db v0.8.0 h1:vUMDaH3ApkX8m0KZvOFFy9b5DZHBAjsnEuo9AKVZpjo=
 github.com/cometbft/cometbft-db v0.8.0/go.mod h1:6ASCP4pfhmrCBpfk01/9E1SI29nD3HfVHrY4PG8x5c0=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=

--- a/e2e/helpers/block_helpers.go
+++ b/e2e/helpers/block_helpers.go
@@ -13,10 +13,3 @@ func GetBlockData(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, 
 	ExecuteQuery(ctx, chain, []string{"query", "block", "--type=height", fmt.Sprintf("%d", height)}, &res)
 	return res
 }
-
-// TODO: replace with `GetTransaction` https://github.com/strangelove-ventures/interchaintest/pull/836
-func GetTxHash(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, txHash string) TxResponse {
-	var res TxResponse
-	ExecuteQuery(ctx, chain, []string{"query", "tx", "--type=hash", txHash}, &res)
-	return res
-}

--- a/e2e/poa_test.go
+++ b/e2e/poa_test.go
@@ -82,7 +82,7 @@ func testUpdatePOAParams(t *testing.T, ctx context.Context, chain *cosmos.Cosmos
 		txRes, err := chain.GetTransaction(tx.Txhash)
 		require.NoError(t, err)
 		fmt.Printf("%+v", txRes)
-		require.EqualValue(t, txRes.Code, 3)
+		require.EqualValues(t, txRes.Code, 3)
 
 		sp := helpers.GetStakingParams(t, ctx, chain)
 		fmt.Printf("%+v", sp)

--- a/e2e/poa_test.go
+++ b/e2e/poa_test.go
@@ -82,7 +82,7 @@ func testUpdatePOAParams(t *testing.T, ctx context.Context, chain *cosmos.Cosmos
 		txRes, err := chain.GetTransaction(tx.Txhash)
 		require.NoError(t, err)
 		fmt.Printf("%+v", txRes)
-		require.Equal(t, txRes.Code, 3)
+		require.EqualValue(t, txRes.Code, 3)
 
 		sp := helpers.GetStakingParams(t, ctx, chain)
 		fmt.Printf("%+v", sp)

--- a/e2e/poa_test.go
+++ b/e2e/poa_test.go
@@ -105,7 +105,7 @@ func testUpdatePOAParams(t *testing.T, ctx context.Context, chain *cosmos.Cosmos
 		txRes, err := chain.GetTransaction(tx.Txhash)
 		require.NoError(t, err)
 		fmt.Printf("%+v", txRes)
-		require.Equal(t, txRes.Code, 0)
+		require.EqualValues(t, txRes.Code, 0)
 
 		sp := helpers.GetStakingParams(t, ctx, chain)
 		fmt.Printf("%+v", sp)
@@ -124,7 +124,7 @@ func testUpdatePOAParams(t *testing.T, ctx context.Context, chain *cosmos.Cosmos
 		txRes, err := chain.GetTransaction(tx.Txhash)
 		require.NoError(t, err)
 		fmt.Printf("%+v", txRes)
-		require.Equal(t, txRes.Code, 0)
+		require.EqualValues(t, txRes.Code, 0)
 
 		p := helpers.GetPOAParams(t, ctx, chain)
 		for _, admin := range newAdmins {

--- a/e2e/poa_test.go
+++ b/e2e/poa_test.go
@@ -162,11 +162,11 @@ func testRemoveValidator(t *testing.T, ctx context.Context, chain *cosmos.Cosmos
 	require.Equal(t, vals[0].Tokens, fmt.Sprintf("%d", powerOne))
 	require.Equal(t, vals[1].Tokens, fmt.Sprintf("%d", powerTwo))
 
-	// === Remove Validator Test ===
+	// remove the 2nd validator (lower power)
 	helpers.POARemove(t, ctx, chain, acc0, validators[1])
 
 	// allow the poa.BeginBlocker to update new status
-	if err := testutil.WaitForBlocks(ctx, 2, chain); err != nil {
+	if err := testutil.WaitForBlocks(ctx, 5, chain); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	cosmossdk.io/log v1.2.1
 	cosmossdk.io/math v1.2.0
 	cosmossdk.io/store v1.0.0
-	github.com/cometbft/cometbft v0.38.0
+	github.com/cometbft/cometbft v0.38.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3
 	github.com/cosmos/cosmos-sdk v0.50.1
 	github.com/cosmos/gogoproto v1.4.11

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/cometbft/cometbft v0.38.0 h1:ogKnpiPX7gxCvqTEF4ly25/wAxUqf181t30P3vqdpdc=
-github.com/cometbft/cometbft v0.38.0/go.mod h1:5Jz0Z8YsHSf0ZaAqGvi/ifioSdVFPtEGrm8Y9T/993k=
+github.com/cometbft/cometbft v0.38.1 h1:hflfGk/VrPapfHco3rgCqn2YpOglAqJshSdyrM2zSLk=
+github.com/cometbft/cometbft v0.38.1/go.mod h1:PIi48BpzwlHqtV3mzwPyQgOyOnU94BNBimLS2ebBHOg=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=

--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -30,6 +30,24 @@ func (k *Keeper) InitGenesis(ctx context.Context, data *poa.GenesisState) error 
 	return nil
 }
 
+// InitStores sets the base cached values from the genesis state in relation to the validator set.
+func (k *Keeper) InitCacheStores(ctx context.Context) error {
+	currValPower, err := k.GetStakingKeeper().GetLastTotalPower(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := k.SetCachedBlockPower(ctx, currValPower.Uint64()); err != nil {
+		return err
+	}
+
+	if err := k.SetAbsoluteChangedInBlockPower(ctx, 0); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // ExportGenesis exports the module's state to a genesis state.
 func (k *Keeper) ExportGenesis(ctx context.Context) *poa.GenesisState {
 	params, err := k.GetParams(ctx)

--- a/keeper/genesis_test.go
+++ b/keeper/genesis_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestInitGenesis(t *testing.T) {
-	fixture := SetupTest(t)
+	fixture := SetupTest(t, 2_000_000)
 
 	t.Run("default params", func(t *testing.T) {
 		data := &poa.GenesisState{

--- a/keeper/genesis_test.go
+++ b/keeper/genesis_test.go
@@ -5,10 +5,16 @@ import (
 
 	"github.com/strangelove-ventures/poa"
 	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 func TestInitGenesis(t *testing.T) {
 	fixture := SetupTest(t, 2_000_000)
+	require := require.New(t)
 
 	t.Run("default params", func(t *testing.T) {
 		data := &poa.GenesisState{
@@ -16,29 +22,54 @@ func TestInitGenesis(t *testing.T) {
 			Params:            poa.DefaultParams(),
 		}
 		err := fixture.k.InitGenesis(fixture.ctx, data)
-		require.NoError(t, err)
+		require.NoError(err)
 
 		params, err := fixture.k.GetParams(fixture.ctx)
-		require.NoError(t, err)
-		require.Equal(t, poa.DefaultParams(), params)
+		require.NoError(err)
+		require.Equal(poa.DefaultParams(), params)
 	})
 
 	// check custom
 	t.Run("custom params", func(t *testing.T) {
 		p, err := poa.NewParams([]string{fixture.addrs[0].String(), fixture.addrs[1].String()})
-		require.NoError(t, err)
+		require.NoError(err)
 
 		data := &poa.GenesisState{
 			PendingValidators: []poa.Validator{},
 			Params:            p,
 		}
 		err = fixture.k.InitGenesis(fixture.ctx, data)
-		require.NoError(t, err)
+		require.NoError(err)
 
 		params, err := fixture.k.GetParams(fixture.ctx)
-		require.NoError(t, err)
-		require.Equal(t, p, params)
+		require.NoError(err)
+		require.Equal(p, params)
 	})
 
-	// TODO: PendingValidators
+	t.Run("pending validator export", func(t *testing.T) {
+		p, err := poa.NewParams([]string{fixture.addrs[0].String(), fixture.addrs[1].String()})
+		require.NoError(err)
+
+		acc := GenAcc()
+		valAddr := sdk.ValAddress(acc.addr)
+
+		val, err := stakingtypes.NewValidator(valAddr.String(), acc.valKey.PubKey(), stakingtypes.Description{})
+		require.NoError(err)
+
+		val.Tokens = sdkmath.NewInt(1_234_567)
+
+		err = fixture.k.InitGenesis(fixture.ctx, &poa.GenesisState{
+			PendingValidators: []poa.Validator{
+				poa.ConvertStakingToPOA(val),
+			},
+			Params: p,
+		})
+		require.NoError(err)
+
+		exported := fixture.k.ExportGenesis(fixture.ctx)
+		require.Equal(1, len(exported.PendingValidators))
+		require.Equal(valAddr.String(), exported.PendingValidators[0].OperatorAddress)
+		require.Equal(val.Tokens, exported.PendingValidators[0].Tokens)
+	})
+
 }

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -166,7 +166,6 @@ func (f *testFixture) createBaseStakingValidators(t *testing.T) {
 		// increase the block so the new validator is in the validator set
 		_, err = f.IncreaseBlock(1)
 		require.NoError(t, err)
-		// fmt.Printf("createBaseStakingValidators updates : %+v", updates)
 
 		valAddrBz, err := sdk.ValAddressFromBech32(val.GetOperator())
 		require.NoError(t, err)
@@ -182,6 +181,10 @@ func (f *testFixture) createBaseStakingValidators(t *testing.T) {
 
 	total := bondCoin.Amount.MulRaw(int64(len(vals)))
 	if err := f.stakingKeeper.SetLastTotalPower(f.ctx, total); err != nil {
+		panic(err)
+	}
+
+	if err := f.k.InitCacheStores(f.ctx); err != nil {
 		panic(err)
 	}
 }

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -68,6 +68,7 @@ type testFixture struct {
 
 func SetupTest(t *testing.T, baseValShares int64) *testFixture {
 	s := new(testFixture)
+	require := require.New(t)
 
 	logger := log.NewTestLogger(t)
 	s.govModAddr = authtypes.NewModuleAddress(govtypes.ModuleName).String()
@@ -87,11 +88,11 @@ func SetupTest(t *testing.T, baseValShares int64) *testFixture {
 
 	s.stakingKeeper = stakingkeeper.NewKeeper(encCfg.Codec, storeService, s.accountkeeper, s.bankkeeper, s.govModAddr, authcodec.NewBech32Codec(sdk.Bech32PrefixValAddr), authcodec.NewBech32Codec(sdk.Bech32PrefixConsAddr))
 	err := s.stakingKeeper.SetParams(s.ctx, stakingtypes.DefaultParams())
-	require.NoError(t, err)
+	require.NoError(err)
 
 	s.slashingKeeper = slashingkeeper.NewKeeper(encCfg.Codec, encCfg.Amino, storeService, s.stakingKeeper, authtypes.NewModuleAddress(govtypes.ModuleName).String())
 	err = s.slashingKeeper.SetParams(s.ctx, slashingtypes.DefaultParams())
-	require.NoError(t, err)
+	require.NoError(err)
 
 	s.k = keeper.NewKeeper(encCfg.Codec, storeService, s.stakingKeeper, s.slashingKeeper, addresscodec.NewBech32Codec("cosmosvaloper"))
 	s.msgServer = keeper.NewMsgServerImpl(s.k)
@@ -106,7 +107,7 @@ func SetupTest(t *testing.T, baseValShares int64) *testFixture {
 	genState := poa.NewGenesisState()
 	genState.Params.Admins = []string{s.addrs[0].String(), s.govModAddr}
 	err = s.k.InitGenesis(s.ctx, genState)
-	require.NoError(t, err)
+	require.NoError(err)
 
 	s.createBaseStakingValidators(t, baseValShares)
 	return s
@@ -131,6 +132,7 @@ func GenAcc() valSetup {
 }
 
 func (f *testFixture) createBaseStakingValidators(t *testing.T, baseValShares int64) {
+	require := require.New(t)
 	bondCoin := sdk.NewCoin("stake", math.NewInt(baseValShares))
 
 	vals := []valSetup{
@@ -161,17 +163,17 @@ func (f *testFixture) createBaseStakingValidators(t *testing.T, baseValShares in
 			Power:            bondCoin.Amount.Uint64(),
 			Unsafe:           true,
 		})
-		require.NoError(t, err)
+		require.NoError(err)
 
 		// increase the block so the new validator is in the validator set
 		_, err = f.IncreaseBlock(1)
-		require.NoError(t, err)
+		require.NoError(err)
 
 		valAddrBz, err := sdk.ValAddressFromBech32(val.GetOperator())
-		require.NoError(t, err)
+		require.NoError(err)
 
 		validator, err := f.stakingKeeper.GetValidator(f.ctx, valAddrBz)
-		require.NoError(t, err)
+		require.NoError(err)
 
 		validator.Status = stakingtypes.Bonded
 		if err := f.stakingKeeper.SetValidator(f.ctx, validator); err != nil {

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -327,7 +327,6 @@ func (ms msgServer) updatePOAPower(ctx context.Context, valOpBech32 string, newP
 		"New Power", newPower,
 		"Prev Power", previousPower,
 		"absPowerDiff", absPowerDiff,
-		"percent change", fmt.Sprintf("%v%%", (absPowerDiff*100)/uint64(previousPower)),
 	)
 
 	if err := ms.k.IncreaseAbsoluteChangedInBlockPower(ctx, absPowerDiff); err != nil {

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -309,7 +309,7 @@ func (ms msgServer) updatePOAPower(ctx context.Context, valOpBech32 string, newP
 		return stakingtypes.Validator{}, err
 	}
 
-	// TODO: For some reason GetLastValidatorPower only returns singkle diget powers on test setup.
+	// TODO: For some reason GetLastValidatorPower only returns single digit powers on test setup.
 	// I am unsure if this is due to a test mis-configure or an issue with POA logic (thus these lines would fix it)
 	// need to dive into the x/staking / cometBFT power requirements to see why a single digit number is used instead of udenom.
 	if previousPower < 1_000_000 {
@@ -322,11 +322,13 @@ func (ms msgServer) updatePOAPower(ctx context.Context, valOpBech32 string, newP
 
 	absPowerDiff := uint64(math.Abs(float64(newPower - previousPower)))
 
-	// print absPowerDiff
-	fmt.Printf("\nvalOpBech32: %s\n", valOpBech32)
-	fmt.Printf("New Power: %d\n", newPower)
-	fmt.Printf("Prev Power: %d\n", previousPower)
-	fmt.Printf("absPowerDiff: %d\n", absPowerDiff)
+	ms.k.Logger(ctx).Debug("POA updatePOAPower",
+		"valOpBech32", valOpBech32,
+		"New Power", newPower,
+		"Prev Power", previousPower,
+		"absPowerDiff", absPowerDiff,
+		"percent change", fmt.Sprintf("%v%%", (absPowerDiff*100)/uint64(previousPower)),
+	)
 
 	if err := ms.k.IncreaseAbsoluteChangedInBlockPower(ctx, absPowerDiff); err != nil {
 		return stakingtypes.Validator{}, err

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestUpdateParams(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 2_000_000)
 	require := require.New(t)
 
 	testCases := []struct {
@@ -59,7 +59,7 @@ func TestUpdateParams(t *testing.T) {
 }
 
 func TestUpdateStakingParams(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 2_000_000)
 	require := require.New(t)
 
 	testCases := []struct {
@@ -107,7 +107,7 @@ func TestUpdateStakingParams(t *testing.T) {
 }
 
 func TestSetPowerAndCreateValidator(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 2_000_000)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
@@ -196,7 +196,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 }
 
 func TestRemoveValidator(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 2_000_000)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
@@ -273,73 +273,77 @@ func TestRemoveValidator(t *testing.T) {
 	}
 }
 
-func TestGlobalPowerUpdates(t *testing.T) {
-	f := SetupTest(t)
+func TestMultipleUpdatesInASingleBlock(t *testing.T) {
+	f := SetupTest(t, 3_000_000)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
 	require.NoError(err)
 
-	totalValTokens := math.ZeroInt()
-	for _, val := range vals {
-		totalValTokens = totalValTokens.Add(val.Tokens)
+	totalPower := 0
+	for _, v := range vals {
+		totalPower += int(v.GetBondedTokens().Int64())
+	}
+
+	if _, err := f.IncreaseBlock(5, true); err != nil {
+		panic(err)
 	}
 
 	testCases := []struct {
 		name               string
 		createNewValidator bool
-		request            *poa.MsgSetPower
+		request            []*poa.MsgSetPower
+		expectedErrIdx     int
 		expectErrMsg       string
 	}{
 		{
 			name:               "new validator swing",
 			createNewValidator: true,
-			request: &poa.MsgSetPower{
-				Sender: f.addrs[0].String(),
-				Power:  2_000_000,
-				Unsafe: true,
+			request: []*poa.MsgSetPower{
+				// 11.11%
+				{
+					Sender:           f.addrs[0].String(),
+					ValidatorAddress: vals[0].OperatorAddress,
+					Power:            4_000_000,
+					Unsafe:           false,
+				},
+				// 22.22%
+				{
+					Sender:           f.addrs[0].String(),
+					ValidatorAddress: vals[1].OperatorAddress,
+					Power:            4_000_000,
+					Unsafe:           false,
+				},
+				// 33.33% modified (>30)
+				{
+					Sender:           f.addrs[0].String(),
+					ValidatorAddress: vals[2].OperatorAddress,
+					Power:            4_000_000,
+					Unsafe:           false,
+				},
 			},
-			expectErrMsg: "",
+			expectedErrIdx: 2,
+			expectErrMsg:   "msg.Power is >30%% of total power, set unsafe=true to override",
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
-			// increase block
 			if _, err := f.IncreaseBlock(1); err != nil {
 				panic(err)
 			}
 
-			// get total set power
-			total, err := f.stakingKeeper.GetLastTotalPower(f.ctx)
-			require.NoError(err)
-			require.EqualValues(totalValTokens, total)
+			for idx, req := range tc.request {
+				_, err = f.msgServer.SetPower(f.ctx, req)
 
-			// add a new validator if the test case requires it
-			if tc.createNewValidator {
-				valAddr := f.CreatePendingValidator(fmt.Sprintf("val-%s", tc.name), tc.request.Power)
-				tc.request.ValidatorAddress = valAddr.String()
-
-				// check the pending validators includes the new validator
-				pendingVals, err := f.k.GetPendingValidators(f.ctx)
-				require.NoError(err)
-				require.EqualValues(1, len(pendingVals.Validators))
+				if idx == tc.expectedErrIdx {
+					require.Error(err)
+					require.ErrorContains(err, tc.expectErrMsg)
+				} else {
+					require.NoError(err)
+				}
 			}
-
-			_, err = f.msgServer.SetPower(f.ctx, tc.request)
-			if tc.expectErrMsg != "" {
-				require.Error(err)
-				require.ErrorContains(err, tc.expectErrMsg)
-			} else {
-				require.NoError(err)
-			}
-
-			// verify that it goes up the Power request amount
-			total, err = f.stakingKeeper.GetLastTotalPower(f.ctx)
-			require.NoError(err)
-			require.EqualValues(totalValTokens.AddRaw(int64(tc.request.Power)), total)
 		})
 	}
 }

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -216,7 +216,6 @@ func TestRemoveValidator(t *testing.T) {
 
 	updates, err := f.IncreaseBlock(1, true)
 	require.NoError(err)
-	fmt.Printf("%+v", updates)
 	require.EqualValues(3, len(updates))
 
 	testCases := []struct {

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPendingValidatorsQuery(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 1_000_000)
 	require := require.New(t)
 
 	// create many validators and query all
@@ -45,7 +45,7 @@ func TestPendingValidatorsQuery(t *testing.T) {
 }
 
 func TestParamsQuery(t *testing.T) {
-	f := SetupTest(t)
+	f := SetupTest(t, 1_000_000)
 	require := require.New(t)
 
 	testCases := []struct {

--- a/keeper/store.go
+++ b/keeper/store.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"encoding/binary"
 
 	"github.com/strangelove-ventures/poa"
 )
@@ -29,4 +30,60 @@ func (k Keeper) GetParams(ctx context.Context) (poa.Params, error) {
 	var p poa.Params
 	k.cdc.MustUnmarshal(bz, &p)
 	return p, nil
+}
+
+// SetCachedBlockPower sets the cached block power.
+func (k Keeper) SetCachedBlockPower(ctx context.Context, power uint64) error {
+	store := k.storeService.OpenKVStore(ctx)
+
+	// convert power to bytes
+	bz := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bz, power)
+
+	return store.Set(poa.CachedPreviousBlockPowerKey, bz)
+}
+
+// GetCachedBlockPower gets the cached block power.
+func (k Keeper) GetCachedBlockPower(ctx context.Context) (uint64, error) {
+	store := k.storeService.OpenKVStore(ctx)
+
+	bz, err := store.Get(poa.CachedPreviousBlockPowerKey)
+	if err != nil || bz == nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint64(bz), nil
+}
+
+// SetAbsoluteChangedInBlockPower sets the absolute changed in block power.
+func (k Keeper) SetAbsoluteChangedInBlockPower(ctx context.Context, power uint64) error {
+	store := k.storeService.OpenKVStore(ctx)
+
+	// convert power to bytes
+	bz := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bz, power)
+
+	return store.Set(poa.AbsoluteChangedInBlockPowerKey, bz)
+}
+
+// GetAbsoluteChangedInBlockPower gets the absolute changed in block power.
+func (k Keeper) GetAbsoluteChangedInBlockPower(ctx context.Context) (uint64, error) {
+	store := k.storeService.OpenKVStore(ctx)
+
+	bz, err := store.Get(poa.AbsoluteChangedInBlockPowerKey)
+	if err != nil || bz == nil {
+		return 0, err
+	}
+
+	return binary.LittleEndian.Uint64(bz), nil
+}
+
+// IncreaseAbsoluteChangedInBlockPower increases the absolute changed in block power by an amount.
+func (k Keeper) IncreaseAbsoluteChangedInBlockPower(ctx context.Context, power uint64) error {
+	getAbs, err := k.GetAbsoluteChangedInBlockPower(ctx)
+	if err != nil {
+		return err
+	}
+
+	return k.SetAbsoluteChangedInBlockPower(ctx, getAbs+power)
 }

--- a/keys.go
+++ b/keys.go
@@ -7,6 +7,13 @@ import (
 var (
 	ParamsKey            = collections.NewPrefix(0)
 	PendingValidatorsKey = collections.NewPrefix(1)
+
+	// CachedPreviousBlockPowerKey saves the previous blocks total delegated power amount.
+	CachedPreviousBlockPowerKey = collections.NewPrefix(2)
+
+	// AbsoluteChangedInBlockPowerKey tracks the current blocks total delegated power amount.
+	// If this becomes >30% of CachedPreviousBlockPowerKey, messages will fail to limit IBC issues.
+	AbsoluteChangedInBlockPowerKey = collections.NewPrefix(3)
 )
 
 const (

--- a/module/abci.go
+++ b/module/abci.go
@@ -38,12 +38,7 @@ func (am AppModule) BeginBlocker(ctx context.Context) error {
 
 	// if it is not a genTx, reset values to the expected
 	if sdkCtx.BlockHeight() > 1 {
-		currValPower, err := am.keeper.GetStakingKeeper().GetLastTotalPower(ctx)
-		if err != nil {
-			return err
-		}
-
-		if err := am.resetCachedTotalPower(ctx, currValPower.Uint64()); err != nil {
+		if err := am.resetCachedTotalPower(ctx); err != nil {
 			return err
 		}
 
@@ -56,14 +51,19 @@ func (am AppModule) BeginBlocker(ctx context.Context) error {
 }
 
 // resetCachedTotalPower resets the cached total power to the new TotalPower index.
-func (am AppModule) resetCachedTotalPower(ctx context.Context, currValPower uint64) error {
+func (am AppModule) resetCachedTotalPower(ctx context.Context) error {
+	currValPower, err := am.keeper.GetStakingKeeper().GetLastTotalPower(ctx)
+	if err != nil {
+		return err
+	}
+
 	prev, err := am.keeper.GetCachedBlockPower(ctx)
 	if err != nil {
 		return err
 	}
 
-	if currValPower != prev {
-		return am.keeper.SetAbsoluteChangedInBlockPower(ctx, currValPower-prev)
+	if currValPower.Uint64() != prev {
+		return am.keeper.SetAbsoluteChangedInBlockPower(ctx, currValPower.Uint64()-prev)
 	}
 
 	return nil

--- a/module/abci.go
+++ b/module/abci.go
@@ -36,13 +36,13 @@ func (am AppModule) BeginBlocker(ctx context.Context) error {
 		}
 	}
 
-	currValPower, err := am.keeper.GetStakingKeeper().GetLastTotalPower(ctx)
-	if err != nil {
-		return err
-	}
-
+	// if it is not a genTx, reset values to the expected
 	if sdkCtx.BlockHeight() > 1 {
-		// if it is not a genTx, reset values to the expected
+		currValPower, err := am.keeper.GetStakingKeeper().GetLastTotalPower(ctx)
+		if err != nil {
+			return err
+		}
+
 		if err := am.resetCachedTotalPower(ctx, currValPower.Uint64()); err != nil {
 			return err
 		}
@@ -50,16 +50,6 @@ func (am AppModule) BeginBlocker(ctx context.Context) error {
 		if err := am.resetAbsoluteBlockPower(ctx); err != nil {
 			return err
 		}
-	} else {
-		// it is a gentx, set the initial stores to the expected values
-		if err := am.keeper.SetCachedBlockPower(ctx, currValPower.Uint64()); err != nil {
-			return err
-		}
-
-		if err := am.keeper.SetAbsoluteChangedInBlockPower(ctx, 0); err != nil {
-			return err
-		}
-
 	}
 
 	return nil

--- a/module/module.go
+++ b/module/module.go
@@ -63,7 +63,7 @@ func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *gwrunt
 	}
 }
 
-// GetTxCmd returns the root tx command for the bank module.
+// GetTxCmd returns the root tx command for the poa module.
 func (am AppModule) GetTxCmd() *cobra.Command {
 	return cli.NewTxCmd(am.cdc.InterfaceRegistry().SigningContext().ValidatorAddressCodec())
 }
@@ -110,6 +110,10 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.
 	cdc.MustUnmarshalJSON(data, &genesisState)
 
 	if err := am.keeper.InitGenesis(ctx, &genesisState); err != nil {
+		panic(err)
+	}
+
+	if err := am.keeper.InitCacheStores(ctx); err != nil {
 		panic(err)
 	}
 

--- a/params.go
+++ b/params.go
@@ -20,19 +20,19 @@ func DefaultParams() Params {
 }
 
 // NewParams returns a new POA Params.
-func NewParams(addresses []string) (Params, error) {
-	if len(addresses) == 0 {
+func NewParams(admins []string) (Params, error) {
+	if len(admins) == 0 {
 		return Params{}, ErrMustProvideAtLeastOneAddress
 	}
 
-	for _, address := range addresses {
+	for _, address := range admins {
 		if _, err := sdk.AccAddressFromBech32(address); err != nil {
 			return Params{}, err
 		}
 	}
 
 	return Params{
-		Admins: addresses,
+		Admins: admins,
 	}, nil
 }
 

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -31,7 +31,7 @@ require (
 	cosmossdk.io/x/nft v0.0.0-20230925151519-64e0e8980834
 	cosmossdk.io/x/tx v0.12.0
 	cosmossdk.io/x/upgrade v0.0.0-20230925151519-64e0e8980834
-	github.com/cometbft/cometbft v0.38.0
+	github.com/cometbft/cometbft v0.38.1
 	github.com/cosmos/cosmos-db v1.0.0
 	github.com/cosmos/cosmos-sdk v0.50.1
 	github.com/cosmos/gogoproto v1.4.11

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -341,8 +341,8 @@ github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/cometbft/cometbft v0.38.0 h1:ogKnpiPX7gxCvqTEF4ly25/wAxUqf181t30P3vqdpdc=
-github.com/cometbft/cometbft v0.38.0/go.mod h1:5Jz0Z8YsHSf0ZaAqGvi/ifioSdVFPtEGrm8Y9T/993k=
+github.com/cometbft/cometbft v0.38.1 h1:hflfGk/VrPapfHco3rgCqn2YpOglAqJshSdyrM2zSLk=
+github.com/cometbft/cometbft v0.38.1/go.mod h1:PIi48BpzwlHqtV3mzwPyQgOyOnU94BNBimLS2ebBHOg=
 github.com/cometbft/cometbft-db v0.8.0 h1:vUMDaH3ApkX8m0KZvOFFy9b5DZHBAjsnEuo9AKVZpjo=
 github.com/cometbft/cometbft-db v0.8.0/go.mod h1:6ASCP4pfhmrCBpfk01/9E1SI29nD3HfVHrY4PG8x5c0=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=


### PR DESCRIPTION
closes #46 

This only affects a large arrays of message to update power (from previous cached power)

Ex
- TotalSetPower = 10TOKENS
- We update 4 validators to have 1TOKEN more each
- the 3rd validator fails since (1+1+1)/10 = >=30% modified in a single block
- State is rolled back (with a single message) else it is cut off at <30% 
- can be bypassed with *unsafe* message flag

note: this does not fix the ability to do this over multiple messages. That is on the admin for miss-management if they attempt to bypass this within the trusting period of the IBC client

## todo:
- [x] move the init store sets to InitChain / gentx
- [x] in keeper_test, IncBlock after setting all vals. then set power, then inc again.
- [x] add test (execute different msg updates power in parallel and ensure anything about 30% change errors)