### PR TITLE
optional: reduce SetPower to single digits

### DIFF
--- a/api/v1/query.pulsar.go
+++ b/api/v1/query.pulsar.go
@@ -1655,6 +1655,830 @@ func (x *fastReflection_PendingValidatorsResponse) ProtoMethods() *protoiface.Me
 	}
 }
 
+var (
+	md_QueryConsensusPowerRequest                   protoreflect.MessageDescriptor
+	fd_QueryConsensusPowerRequest_validator_address protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_strangelove_ventures_poa_v1_query_proto_init()
+	md_QueryConsensusPowerRequest = File_strangelove_ventures_poa_v1_query_proto.Messages().ByName("QueryConsensusPowerRequest")
+	fd_QueryConsensusPowerRequest_validator_address = md_QueryConsensusPowerRequest.Fields().ByName("validator_address")
+}
+
+var _ protoreflect.Message = (*fastReflection_QueryConsensusPowerRequest)(nil)
+
+type fastReflection_QueryConsensusPowerRequest QueryConsensusPowerRequest
+
+func (x *QueryConsensusPowerRequest) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_QueryConsensusPowerRequest)(x)
+}
+
+func (x *QueryConsensusPowerRequest) slowProtoReflect() protoreflect.Message {
+	mi := &file_strangelove_ventures_poa_v1_query_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_QueryConsensusPowerRequest_messageType fastReflection_QueryConsensusPowerRequest_messageType
+var _ protoreflect.MessageType = fastReflection_QueryConsensusPowerRequest_messageType{}
+
+type fastReflection_QueryConsensusPowerRequest_messageType struct{}
+
+func (x fastReflection_QueryConsensusPowerRequest_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_QueryConsensusPowerRequest)(nil)
+}
+func (x fastReflection_QueryConsensusPowerRequest_messageType) New() protoreflect.Message {
+	return new(fastReflection_QueryConsensusPowerRequest)
+}
+func (x fastReflection_QueryConsensusPowerRequest_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_QueryConsensusPowerRequest
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_QueryConsensusPowerRequest) Descriptor() protoreflect.MessageDescriptor {
+	return md_QueryConsensusPowerRequest
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_QueryConsensusPowerRequest) Type() protoreflect.MessageType {
+	return _fastReflection_QueryConsensusPowerRequest_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_QueryConsensusPowerRequest) New() protoreflect.Message {
+	return new(fastReflection_QueryConsensusPowerRequest)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_QueryConsensusPowerRequest) Interface() protoreflect.ProtoMessage {
+	return (*QueryConsensusPowerRequest)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_QueryConsensusPowerRequest) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.ValidatorAddress != "" {
+		value := protoreflect.ValueOfString(x.ValidatorAddress)
+		if !f(fd_QueryConsensusPowerRequest_validator_address, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_QueryConsensusPowerRequest) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		return x.ValidatorAddress != ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerRequest) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		x.ValidatorAddress = ""
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_QueryConsensusPowerRequest) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		value := x.ValidatorAddress
+		return protoreflect.ValueOfString(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerRequest) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		x.ValidatorAddress = value.Interface().(string)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerRequest) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		panic(fmt.Errorf("field validator_address of message strangelove_ventures.poa.v1.QueryConsensusPowerRequest is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_QueryConsensusPowerRequest) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerRequest.validator_address":
+		return protoreflect.ValueOfString("")
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerRequest"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerRequest does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_QueryConsensusPowerRequest) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in strangelove_ventures.poa.v1.QueryConsensusPowerRequest", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_QueryConsensusPowerRequest) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerRequest) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_QueryConsensusPowerRequest) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_QueryConsensusPowerRequest) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*QueryConsensusPowerRequest)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		l = len(x.ValidatorAddress)
+		if l > 0 {
+			n += 1 + l + runtime.Sov(uint64(l))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*QueryConsensusPowerRequest)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if len(x.ValidatorAddress) > 0 {
+			i -= len(x.ValidatorAddress)
+			copy(dAtA[i:], x.ValidatorAddress)
+			i = runtime.EncodeVarint(dAtA, i, uint64(len(x.ValidatorAddress)))
+			i--
+			dAtA[i] = 0xa
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*QueryConsensusPowerRequest)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: QueryConsensusPowerRequest: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: QueryConsensusPowerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 2 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ValidatorAddress", wireType)
+				}
+				var stringLen uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					stringLen |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				intStringLen := int(stringLen)
+				if intStringLen < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				postIndex := iNdEx + intStringLen
+				if postIndex < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if postIndex > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				x.ValidatorAddress = string(dAtA[iNdEx:postIndex])
+				iNdEx = postIndex
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
+var (
+	md_QueryConsensusPowerResponse                 protoreflect.MessageDescriptor
+	fd_QueryConsensusPowerResponse_consensus_power protoreflect.FieldDescriptor
+)
+
+func init() {
+	file_strangelove_ventures_poa_v1_query_proto_init()
+	md_QueryConsensusPowerResponse = File_strangelove_ventures_poa_v1_query_proto.Messages().ByName("QueryConsensusPowerResponse")
+	fd_QueryConsensusPowerResponse_consensus_power = md_QueryConsensusPowerResponse.Fields().ByName("consensus_power")
+}
+
+var _ protoreflect.Message = (*fastReflection_QueryConsensusPowerResponse)(nil)
+
+type fastReflection_QueryConsensusPowerResponse QueryConsensusPowerResponse
+
+func (x *QueryConsensusPowerResponse) ProtoReflect() protoreflect.Message {
+	return (*fastReflection_QueryConsensusPowerResponse)(x)
+}
+
+func (x *QueryConsensusPowerResponse) slowProtoReflect() protoreflect.Message {
+	mi := &file_strangelove_ventures_poa_v1_query_proto_msgTypes[5]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+var _fastReflection_QueryConsensusPowerResponse_messageType fastReflection_QueryConsensusPowerResponse_messageType
+var _ protoreflect.MessageType = fastReflection_QueryConsensusPowerResponse_messageType{}
+
+type fastReflection_QueryConsensusPowerResponse_messageType struct{}
+
+func (x fastReflection_QueryConsensusPowerResponse_messageType) Zero() protoreflect.Message {
+	return (*fastReflection_QueryConsensusPowerResponse)(nil)
+}
+func (x fastReflection_QueryConsensusPowerResponse_messageType) New() protoreflect.Message {
+	return new(fastReflection_QueryConsensusPowerResponse)
+}
+func (x fastReflection_QueryConsensusPowerResponse_messageType) Descriptor() protoreflect.MessageDescriptor {
+	return md_QueryConsensusPowerResponse
+}
+
+// Descriptor returns message descriptor, which contains only the protobuf
+// type information for the message.
+func (x *fastReflection_QueryConsensusPowerResponse) Descriptor() protoreflect.MessageDescriptor {
+	return md_QueryConsensusPowerResponse
+}
+
+// Type returns the message type, which encapsulates both Go and protobuf
+// type information. If the Go type information is not needed,
+// it is recommended that the message descriptor be used instead.
+func (x *fastReflection_QueryConsensusPowerResponse) Type() protoreflect.MessageType {
+	return _fastReflection_QueryConsensusPowerResponse_messageType
+}
+
+// New returns a newly allocated and mutable empty message.
+func (x *fastReflection_QueryConsensusPowerResponse) New() protoreflect.Message {
+	return new(fastReflection_QueryConsensusPowerResponse)
+}
+
+// Interface unwraps the message reflection interface and
+// returns the underlying ProtoMessage interface.
+func (x *fastReflection_QueryConsensusPowerResponse) Interface() protoreflect.ProtoMessage {
+	return (*QueryConsensusPowerResponse)(x)
+}
+
+// Range iterates over every populated field in an undefined order,
+// calling f for each field descriptor and value encountered.
+// Range returns immediately if f returns false.
+// While iterating, mutating operations may only be performed
+// on the current field descriptor.
+func (x *fastReflection_QueryConsensusPowerResponse) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if x.ConsensusPower != int64(0) {
+		value := protoreflect.ValueOfInt64(x.ConsensusPower)
+		if !f(fd_QueryConsensusPowerResponse_consensus_power, value) {
+			return
+		}
+	}
+}
+
+// Has reports whether a field is populated.
+//
+// Some fields have the property of nullability where it is possible to
+// distinguish between the default value of a field and whether the field
+// was explicitly populated with the default value. Singular message fields,
+// member fields of a oneof, and proto2 scalar fields are nullable. Such
+// fields are populated only if explicitly set.
+//
+// In other cases (aside from the nullable cases above),
+// a proto3 scalar field is populated if it contains a non-zero value, and
+// a repeated field is populated if it is non-empty.
+func (x *fastReflection_QueryConsensusPowerResponse) Has(fd protoreflect.FieldDescriptor) bool {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		return x.ConsensusPower != int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Clear clears the field such that a subsequent Has call reports false.
+//
+// Clearing an extension field clears both the extension type and value
+// associated with the given field number.
+//
+// Clear is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerResponse) Clear(fd protoreflect.FieldDescriptor) {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		x.ConsensusPower = int64(0)
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Get retrieves the value for a field.
+//
+// For unpopulated scalars, it returns the default value, where
+// the default value of a bytes scalar is guaranteed to be a copy.
+// For unpopulated composite types, it returns an empty, read-only view
+// of the value; to obtain a mutable reference, use Mutable.
+func (x *fastReflection_QueryConsensusPowerResponse) Get(descriptor protoreflect.FieldDescriptor) protoreflect.Value {
+	switch descriptor.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		value := x.ConsensusPower
+		return protoreflect.ValueOfInt64(value)
+	default:
+		if descriptor.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", descriptor.FullName()))
+	}
+}
+
+// Set stores the value for a field.
+//
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType.
+// When setting a composite type, it is unspecified whether the stored value
+// aliases the source's memory in any way. If the composite value is an
+// empty, read-only value, then it panics.
+//
+// Set is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerResponse) Set(fd protoreflect.FieldDescriptor, value protoreflect.Value) {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		x.ConsensusPower = value.Int()
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// Mutable returns a mutable reference to a composite type.
+//
+// If the field is unpopulated, it may allocate a composite value.
+// For a field belonging to a oneof, it implicitly clears any other field
+// that may be currently set within the same oneof.
+// For extension fields, it implicitly stores the provided ExtensionType
+// if not already stored.
+// It panics if the field does not contain a composite type.
+//
+// Mutable is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerResponse) Mutable(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		panic(fmt.Errorf("field consensus_power of message strangelove_ventures.poa.v1.QueryConsensusPowerResponse is not mutable"))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// NewField returns a new value that is assignable to the field
+// for the given descriptor. For scalars, this returns the default value.
+// For lists, maps, and messages, this returns a new, empty, mutable value.
+func (x *fastReflection_QueryConsensusPowerResponse) NewField(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	switch fd.FullName() {
+	case "strangelove_ventures.poa.v1.QueryConsensusPowerResponse.consensus_power":
+		return protoreflect.ValueOfInt64(int64(0))
+	default:
+		if fd.IsExtension() {
+			panic(fmt.Errorf("proto3 declared messages do not support extensions: strangelove_ventures.poa.v1.QueryConsensusPowerResponse"))
+		}
+		panic(fmt.Errorf("message strangelove_ventures.poa.v1.QueryConsensusPowerResponse does not contain field %s", fd.FullName()))
+	}
+}
+
+// WhichOneof reports which field within the oneof is populated,
+// returning nil if none are populated.
+// It panics if the oneof descriptor does not belong to this message.
+func (x *fastReflection_QueryConsensusPowerResponse) WhichOneof(d protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	switch d.FullName() {
+	default:
+		panic(fmt.Errorf("%s is not a oneof field in strangelove_ventures.poa.v1.QueryConsensusPowerResponse", d.FullName()))
+	}
+	panic("unreachable")
+}
+
+// GetUnknown retrieves the entire list of unknown fields.
+// The caller may only mutate the contents of the RawFields
+// if the mutated bytes are stored back into the message with SetUnknown.
+func (x *fastReflection_QueryConsensusPowerResponse) GetUnknown() protoreflect.RawFields {
+	return x.unknownFields
+}
+
+// SetUnknown stores an entire list of unknown fields.
+// The raw fields must be syntactically valid according to the wire format.
+// An implementation may panic if this is not the case.
+// Once stored, the caller must not mutate the content of the RawFields.
+// An empty RawFields may be passed to clear the fields.
+//
+// SetUnknown is a mutating operation and unsafe for concurrent use.
+func (x *fastReflection_QueryConsensusPowerResponse) SetUnknown(fields protoreflect.RawFields) {
+	x.unknownFields = fields
+}
+
+// IsValid reports whether the message is valid.
+//
+// An invalid message is an empty, read-only value.
+//
+// An invalid message often corresponds to a nil pointer of the concrete
+// message type, but the details are implementation dependent.
+// Validity is not part of the protobuf data model, and may not
+// be preserved in marshaling or other operations.
+func (x *fastReflection_QueryConsensusPowerResponse) IsValid() bool {
+	return x != nil
+}
+
+// ProtoMethods returns optional fastReflectionFeature-path implementations of various operations.
+// This method may return nil.
+//
+// The returned methods type is identical to
+// "google.golang.org/protobuf/runtime/protoiface".Methods.
+// Consult the protoiface package documentation for details.
+func (x *fastReflection_QueryConsensusPowerResponse) ProtoMethods() *protoiface.Methods {
+	size := func(input protoiface.SizeInput) protoiface.SizeOutput {
+		x := input.Message.Interface().(*QueryConsensusPowerResponse)
+		if x == nil {
+			return protoiface.SizeOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Size:              0,
+			}
+		}
+		options := runtime.SizeInputToOptions(input)
+		_ = options
+		var n int
+		var l int
+		_ = l
+		if x.ConsensusPower != 0 {
+			n += 1 + runtime.Sov(uint64(x.ConsensusPower))
+		}
+		if x.unknownFields != nil {
+			n += len(x.unknownFields)
+		}
+		return protoiface.SizeOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Size:              n,
+		}
+	}
+
+	marshal := func(input protoiface.MarshalInput) (protoiface.MarshalOutput, error) {
+		x := input.Message.Interface().(*QueryConsensusPowerResponse)
+		if x == nil {
+			return protoiface.MarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Buf:               input.Buf,
+			}, nil
+		}
+		options := runtime.MarshalInputToOptions(input)
+		_ = options
+		size := options.Size(x)
+		dAtA := make([]byte, size)
+		i := len(dAtA)
+		_ = i
+		var l int
+		_ = l
+		if x.unknownFields != nil {
+			i -= len(x.unknownFields)
+			copy(dAtA[i:], x.unknownFields)
+		}
+		if x.ConsensusPower != 0 {
+			i = runtime.EncodeVarint(dAtA, i, uint64(x.ConsensusPower))
+			i--
+			dAtA[i] = 0x8
+		}
+		if input.Buf != nil {
+			input.Buf = append(input.Buf, dAtA...)
+		} else {
+			input.Buf = dAtA
+		}
+		return protoiface.MarshalOutput{
+			NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+			Buf:               input.Buf,
+		}, nil
+	}
+	unmarshal := func(input protoiface.UnmarshalInput) (protoiface.UnmarshalOutput, error) {
+		x := input.Message.Interface().(*QueryConsensusPowerResponse)
+		if x == nil {
+			return protoiface.UnmarshalOutput{
+				NoUnkeyedLiterals: input.NoUnkeyedLiterals,
+				Flags:             input.Flags,
+			}, nil
+		}
+		options := runtime.UnmarshalInputToOptions(input)
+		_ = options
+		dAtA := input.Buf
+		l := len(dAtA)
+		iNdEx := 0
+		for iNdEx < l {
+			preIndex := iNdEx
+			var wire uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				wire |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			fieldNum := int32(wire >> 3)
+			wireType := int(wire & 0x7)
+			if wireType == 4 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: QueryConsensusPowerResponse: wiretype end group for non-group")
+			}
+			if fieldNum <= 0 {
+				return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: QueryConsensusPowerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			}
+			switch fieldNum {
+			case 1:
+				if wireType != 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, fmt.Errorf("proto: wrong wireType = %d for field ConsensusPower", wireType)
+				}
+				x.ConsensusPower = 0
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					x.ConsensusPower |= int64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+			default:
+				iNdEx = preIndex
+				skippy, err := runtime.Skip(dAtA[iNdEx:])
+				if err != nil {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, err
+				}
+				if (skippy < 0) || (iNdEx+skippy) < 0 {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, runtime.ErrInvalidLength
+				}
+				if (iNdEx + skippy) > l {
+					return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+				}
+				if !options.DiscardUnknown {
+					x.unknownFields = append(x.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+				}
+				iNdEx += skippy
+			}
+		}
+
+		if iNdEx > l {
+			return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, io.ErrUnexpectedEOF
+		}
+		return protoiface.UnmarshalOutput{NoUnkeyedLiterals: input.NoUnkeyedLiterals, Flags: input.Flags}, nil
+	}
+	return &protoiface.Methods{
+		NoUnkeyedLiterals: struct{}{},
+		Flags:             protoiface.SupportMarshalDeterministic | protoiface.SupportUnmarshalDiscardUnknown,
+		Size:              size,
+		Marshal:           marshal,
+		Unmarshal:         unmarshal,
+		Merge:             nil,
+		CheckInitialized:  nil,
+	}
+}
+
 // Code generated by protoc-gen-go. DO NOT EDIT.
 // versions:
 // 	protoc-gen-go v1.27.0
@@ -1796,6 +2620,80 @@ func (x *PendingValidatorsResponse) GetPending() []*Validator {
 	return nil
 }
 
+// QueryConsensusPowerRequest is the request type for the Query/ConsensusPower RPC method.
+type QueryConsensusPowerRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// validator_address is the address of the validator
+	ValidatorAddress string `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
+}
+
+func (x *QueryConsensusPowerRequest) Reset() {
+	*x = QueryConsensusPowerRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_strangelove_ventures_poa_v1_query_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QueryConsensusPowerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryConsensusPowerRequest) ProtoMessage() {}
+
+// Deprecated: Use QueryConsensusPowerRequest.ProtoReflect.Descriptor instead.
+func (*QueryConsensusPowerRequest) Descriptor() ([]byte, []int) {
+	return file_strangelove_ventures_poa_v1_query_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *QueryConsensusPowerRequest) GetValidatorAddress() string {
+	if x != nil {
+		return x.ValidatorAddress
+	}
+	return ""
+}
+
+// QueryConsensusPowerResponse is the response type for the Query/ConsensusPowerRequest RPC method.
+type QueryConsensusPowerResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// consensus_power is the returned consensus power from the BFT consensus mechanism
+	ConsensusPower int64 `protobuf:"varint,1,opt,name=consensus_power,json=consensusPower,proto3" json:"consensus_power,omitempty"`
+}
+
+func (x *QueryConsensusPowerResponse) Reset() {
+	*x = QueryConsensusPowerResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_strangelove_ventures_poa_v1_query_proto_msgTypes[5]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *QueryConsensusPowerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryConsensusPowerResponse) ProtoMessage() {}
+
+// Deprecated: Use QueryConsensusPowerResponse.ProtoReflect.Descriptor instead.
+func (*QueryConsensusPowerResponse) Descriptor() ([]byte, []int) {
+	return file_strangelove_ventures_poa_v1_query_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *QueryConsensusPowerResponse) GetConsensusPower() int64 {
+	if x != nil {
+		return x.ConsensusPower
+	}
+	return 0
+}
+
 var File_strangelove_ventures_poa_v1_query_proto protoreflect.FileDescriptor
 
 var file_strangelove_ventures_poa_v1_query_proto_rawDesc = []byte{
@@ -1827,43 +2725,63 @@ var file_strangelove_ventures_poa_v1_query_proto_rawDesc = []byte{
 	0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72,
 	0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61,
 	0x74, 0x6f, 0x72, 0x42, 0x04, 0xc8, 0xde, 0x1f, 0x00, 0x52, 0x07, 0x70, 0x65, 0x6e, 0x64, 0x69,
-	0x6e, 0x67, 0x32, 0xb5, 0x02, 0x0a, 0x05, 0x51, 0x75, 0x65, 0x72, 0x79, 0x12, 0x7e, 0x0a, 0x06,
-	0x50, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x12, 0x2f, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65,
-	0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f,
-	0x61, 0x2e, 0x76, 0x31, 0x2e, 0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x73,
-	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67,
-	0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70,
-	0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x52, 0x65, 0x73, 0x70,
-	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x16, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x10, 0x12, 0x0e, 0x2f, 0x70,
-	0x6f, 0x61, 0x2f, 0x76, 0x31, 0x2f, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x12, 0xab, 0x01, 0x0a,
-	0x11, 0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f,
-	0x72, 0x73, 0x12, 0x3a, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65,
-	0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31,
-	0x2e, 0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c,
-	0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x36,
-	0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e,
-	0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x65, 0x6e,
-	0x64, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x52, 0x65,
-	0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x22, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x1c, 0x12, 0x1a,
-	0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x76, 0x31, 0x2f, 0x70, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x5f,
-	0x76, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x42, 0x82, 0x02, 0x0a, 0x1f, 0x63,
-	0x6f, 0x6d, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76,
-	0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x42, 0x0a,
-	0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x49, 0x67, 0x69,
-	0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65,
-	0x6c, 0x6f, 0x76, 0x65, 0x2d, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2f, 0x70, 0x6f,
-	0x61, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76,
-	0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x76,
-	0x31, 0x3b, 0x70, 0x6f, 0x61, 0x76, 0x31, 0xa2, 0x02, 0x03, 0x53, 0x50, 0x58, 0xaa, 0x02, 0x1a,
-	0x53, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56, 0x65, 0x6e, 0x74, 0x75,
-	0x72, 0x65, 0x73, 0x2e, 0x50, 0x6f, 0x61, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x1a, 0x53, 0x74, 0x72,
+	0x6e, 0x67, 0x22, 0x49, 0x0a, 0x1a, 0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x6e, 0x73, 0x65,
+	0x6e, 0x73, 0x75, 0x73, 0x50, 0x6f, 0x77, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74,
+	0x12, 0x2b, 0x0a, 0x11, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x5f, 0x61, 0x64,
+	0x64, 0x72, 0x65, 0x73, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x76, 0x61, 0x6c,
+	0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x41, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x22, 0x46, 0x0a,
+	0x1b, 0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x50,
+	0x6f, 0x77, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x27, 0x0a, 0x0f,
+	0x63, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x5f, 0x70, 0x6f, 0x77, 0x65, 0x72, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x03, 0x52, 0x0e, 0x63, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73,
+	0x50, 0x6f, 0x77, 0x65, 0x72, 0x32, 0xdc, 0x03, 0x0a, 0x05, 0x51, 0x75, 0x65, 0x72, 0x79, 0x12,
+	0x7e, 0x0a, 0x06, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x12, 0x2f, 0x2e, 0x73, 0x74, 0x72, 0x61,
+	0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73,
+	0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x61, 0x72,
+	0x61, 0x6d, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x2b, 0x2e, 0x73, 0x74, 0x72,
+	0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65,
+	0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x16, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x10, 0x12,
+	0x0e, 0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x76, 0x31, 0x2f, 0x70, 0x61, 0x72, 0x61, 0x6d, 0x73, 0x12,
+	0xab, 0x01, 0x0a, 0x11, 0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x69, 0x64,
+	0x61, 0x74, 0x6f, 0x72, 0x73, 0x12, 0x3a, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c,
+	0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61,
+	0x2e, 0x76, 0x31, 0x2e, 0x51, 0x75, 0x65, 0x72, 0x79, 0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67,
+	0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x36, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f,
+	0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e,
+	0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72,
+	0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x22, 0x82, 0xd3, 0xe4, 0x93, 0x02,
+	0x1c, 0x12, 0x1a, 0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x76, 0x31, 0x2f, 0x70, 0x65, 0x6e, 0x64, 0x69,
+	0x6e, 0x67, 0x5f, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x73, 0x12, 0xa4, 0x01,
+	0x0a, 0x0e, 0x43, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x50, 0x6f, 0x77, 0x65, 0x72,
+	0x12, 0x37, 0x2e, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76,
+	0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x51,
+	0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x50, 0x6f, 0x77,
+	0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x38, 0x2e, 0x73, 0x74, 0x72, 0x61,
+	0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73,
+	0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x2e, 0x51, 0x75, 0x65, 0x72, 0x79, 0x43, 0x6f, 0x6e,
+	0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x50, 0x6f, 0x77, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x22, 0x1f, 0x82, 0xd3, 0xe4, 0x93, 0x02, 0x19, 0x12, 0x17, 0x2f, 0x70, 0x6f,
+	0x61, 0x2f, 0x76, 0x31, 0x2f, 0x63, 0x6f, 0x6e, 0x73, 0x65, 0x6e, 0x73, 0x75, 0x73, 0x5f, 0x70,
+	0x6f, 0x77, 0x65, 0x72, 0x42, 0x82, 0x02, 0x0a, 0x1f, 0x63, 0x6f, 0x6d, 0x2e, 0x73, 0x74, 0x72,
+	0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65,
+	0x73, 0x2e, 0x70, 0x6f, 0x61, 0x2e, 0x76, 0x31, 0x42, 0x0a, 0x51, 0x75, 0x65, 0x72, 0x79, 0x50,
+	0x72, 0x6f, 0x74, 0x6f, 0x50, 0x01, 0x5a, 0x49, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
+	0x6f, 0x6d, 0x2f, 0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x2d, 0x76,
+	0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x61, 0x70, 0x69, 0x2f,
+	0x73, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x5f, 0x76, 0x65, 0x6e, 0x74,
+	0x75, 0x72, 0x65, 0x73, 0x2f, 0x70, 0x6f, 0x61, 0x2f, 0x76, 0x31, 0x3b, 0x70, 0x6f, 0x61, 0x76,
+	0x31, 0xa2, 0x02, 0x03, 0x53, 0x50, 0x58, 0xaa, 0x02, 0x1a, 0x53, 0x74, 0x72, 0x61, 0x6e, 0x67,
+	0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x2e, 0x50, 0x6f,
+	0x61, 0x2e, 0x56, 0x31, 0xca, 0x02, 0x1a, 0x53, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f,
+	0x76, 0x65, 0x56, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x5c, 0x50, 0x6f, 0x61, 0x5c, 0x56,
+	0x31, 0xe2, 0x02, 0x26, 0x53, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56,
+	0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x5c, 0x50, 0x6f, 0x61, 0x5c, 0x56, 0x31, 0x5c, 0x47,
+	0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61, 0xea, 0x02, 0x1c, 0x53, 0x74, 0x72,
 	0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73,
-	0x5c, 0x50, 0x6f, 0x61, 0x5c, 0x56, 0x31, 0xe2, 0x02, 0x26, 0x53, 0x74, 0x72, 0x61, 0x6e, 0x67,
-	0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56, 0x65, 0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x5c, 0x50, 0x6f,
-	0x61, 0x5c, 0x56, 0x31, 0x5c, 0x47, 0x50, 0x42, 0x4d, 0x65, 0x74, 0x61, 0x64, 0x61, 0x74, 0x61,
-	0xea, 0x02, 0x1c, 0x53, 0x74, 0x72, 0x61, 0x6e, 0x67, 0x65, 0x6c, 0x6f, 0x76, 0x65, 0x56, 0x65,
-	0x6e, 0x74, 0x75, 0x72, 0x65, 0x73, 0x3a, 0x3a, 0x50, 0x6f, 0x61, 0x3a, 0x3a, 0x56, 0x31, 0x62,
-	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x3a, 0x3a, 0x50, 0x6f, 0x61, 0x3a, 0x3a, 0x56, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f,
+	0x33,
 }
 
 var (
@@ -1878,24 +2796,28 @@ func file_strangelove_ventures_poa_v1_query_proto_rawDescGZIP() []byte {
 	return file_strangelove_ventures_poa_v1_query_proto_rawDescData
 }
 
-var file_strangelove_ventures_poa_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_strangelove_ventures_poa_v1_query_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_strangelove_ventures_poa_v1_query_proto_goTypes = []interface{}{
 	(*QueryParamsRequest)(nil),            // 0: strangelove_ventures.poa.v1.QueryParamsRequest
 	(*ParamsResponse)(nil),                // 1: strangelove_ventures.poa.v1.ParamsResponse
 	(*QueryPendingValidatorsRequest)(nil), // 2: strangelove_ventures.poa.v1.QueryPendingValidatorsRequest
 	(*PendingValidatorsResponse)(nil),     // 3: strangelove_ventures.poa.v1.PendingValidatorsResponse
-	(*Params)(nil),                        // 4: strangelove_ventures.poa.v1.Params
-	(*Validator)(nil),                     // 5: strangelove_ventures.poa.v1.Validator
+	(*QueryConsensusPowerRequest)(nil),    // 4: strangelove_ventures.poa.v1.QueryConsensusPowerRequest
+	(*QueryConsensusPowerResponse)(nil),   // 5: strangelove_ventures.poa.v1.QueryConsensusPowerResponse
+	(*Params)(nil),                        // 6: strangelove_ventures.poa.v1.Params
+	(*Validator)(nil),                     // 7: strangelove_ventures.poa.v1.Validator
 }
 var file_strangelove_ventures_poa_v1_query_proto_depIdxs = []int32{
-	4, // 0: strangelove_ventures.poa.v1.ParamsResponse.params:type_name -> strangelove_ventures.poa.v1.Params
-	5, // 1: strangelove_ventures.poa.v1.PendingValidatorsResponse.pending:type_name -> strangelove_ventures.poa.v1.Validator
+	6, // 0: strangelove_ventures.poa.v1.ParamsResponse.params:type_name -> strangelove_ventures.poa.v1.Params
+	7, // 1: strangelove_ventures.poa.v1.PendingValidatorsResponse.pending:type_name -> strangelove_ventures.poa.v1.Validator
 	0, // 2: strangelove_ventures.poa.v1.Query.Params:input_type -> strangelove_ventures.poa.v1.QueryParamsRequest
 	2, // 3: strangelove_ventures.poa.v1.Query.PendingValidators:input_type -> strangelove_ventures.poa.v1.QueryPendingValidatorsRequest
-	1, // 4: strangelove_ventures.poa.v1.Query.Params:output_type -> strangelove_ventures.poa.v1.ParamsResponse
-	3, // 5: strangelove_ventures.poa.v1.Query.PendingValidators:output_type -> strangelove_ventures.poa.v1.PendingValidatorsResponse
-	4, // [4:6] is the sub-list for method output_type
-	2, // [2:4] is the sub-list for method input_type
+	4, // 4: strangelove_ventures.poa.v1.Query.ConsensusPower:input_type -> strangelove_ventures.poa.v1.QueryConsensusPowerRequest
+	1, // 5: strangelove_ventures.poa.v1.Query.Params:output_type -> strangelove_ventures.poa.v1.ParamsResponse
+	3, // 6: strangelove_ventures.poa.v1.Query.PendingValidators:output_type -> strangelove_ventures.poa.v1.PendingValidatorsResponse
+	5, // 7: strangelove_ventures.poa.v1.Query.ConsensusPower:output_type -> strangelove_ventures.poa.v1.QueryConsensusPowerResponse
+	5, // [5:8] is the sub-list for method output_type
+	2, // [2:5] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
 	2, // [2:2] is the sub-list for extension extendee
 	0, // [0:2] is the sub-list for field type_name
@@ -1957,6 +2879,30 @@ func file_strangelove_ventures_poa_v1_query_proto_init() {
 				return nil
 			}
 		}
+		file_strangelove_ventures_poa_v1_query_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*QueryConsensusPowerRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_strangelove_ventures_poa_v1_query_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*QueryConsensusPowerResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -1964,7 +2910,7 @@ func file_strangelove_ventures_poa_v1_query_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_strangelove_ventures_poa_v1_query_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/v1/query_grpc.pb.go
+++ b/api/v1/query_grpc.pb.go
@@ -21,6 +21,7 @@ const _ = grpc.SupportPackageIsVersion7
 const (
 	Query_Params_FullMethodName            = "/strangelove_ventures.poa.v1.Query/Params"
 	Query_PendingValidators_FullMethodName = "/strangelove_ventures.poa.v1.Query/PendingValidators"
+	Query_ConsensusPower_FullMethodName    = "/strangelove_ventures.poa.v1.Query/ConsensusPower"
 )
 
 // QueryClient is the client API for Query service.
@@ -31,6 +32,8 @@ type QueryClient interface {
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*ParamsResponse, error)
 	// PendingValidators returns currently pending validators of the module.
 	PendingValidators(ctx context.Context, in *QueryPendingValidatorsRequest, opts ...grpc.CallOption) (*PendingValidatorsResponse, error)
+	// ConsensusPower returns the current consensus power of a validator.
+	ConsensusPower(ctx context.Context, in *QueryConsensusPowerRequest, opts ...grpc.CallOption) (*QueryConsensusPowerResponse, error)
 }
 
 type queryClient struct {
@@ -59,6 +62,15 @@ func (c *queryClient) PendingValidators(ctx context.Context, in *QueryPendingVal
 	return out, nil
 }
 
+func (c *queryClient) ConsensusPower(ctx context.Context, in *QueryConsensusPowerRequest, opts ...grpc.CallOption) (*QueryConsensusPowerResponse, error) {
+	out := new(QueryConsensusPowerResponse)
+	err := c.cc.Invoke(ctx, Query_ConsensusPower_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 // All implementations must embed UnimplementedQueryServer
 // for forward compatibility
@@ -67,6 +79,8 @@ type QueryServer interface {
 	Params(context.Context, *QueryParamsRequest) (*ParamsResponse, error)
 	// PendingValidators returns currently pending validators of the module.
 	PendingValidators(context.Context, *QueryPendingValidatorsRequest) (*PendingValidatorsResponse, error)
+	// ConsensusPower returns the current consensus power of a validator.
+	ConsensusPower(context.Context, *QueryConsensusPowerRequest) (*QueryConsensusPowerResponse, error)
 	mustEmbedUnimplementedQueryServer()
 }
 
@@ -79,6 +93,9 @@ func (UnimplementedQueryServer) Params(context.Context, *QueryParamsRequest) (*P
 }
 func (UnimplementedQueryServer) PendingValidators(context.Context, *QueryPendingValidatorsRequest) (*PendingValidatorsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PendingValidators not implemented")
+}
+func (UnimplementedQueryServer) ConsensusPower(context.Context, *QueryConsensusPowerRequest) (*QueryConsensusPowerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConsensusPower not implemented")
 }
 func (UnimplementedQueryServer) mustEmbedUnimplementedQueryServer() {}
 
@@ -129,6 +146,24 @@ func _Query_PendingValidators_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_ConsensusPower_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryConsensusPowerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ConsensusPower(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Query_ConsensusPower_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ConsensusPower(ctx, req.(*QueryConsensusPowerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Query_ServiceDesc is the grpc.ServiceDesc for Query service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -143,6 +178,10 @@ var Query_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PendingValidators",
 			Handler:    _Query_PendingValidators_Handler,
+		},
+		{
+			MethodName: "ConsensusPower",
+			Handler:    _Query_ConsensusPower_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/e2e/helpers/poa_helpers.go
+++ b/e2e/helpers/poa_helpers.go
@@ -51,9 +51,22 @@ func SubmitGovernanceProposalForValidatorChanges(t *testing.T, ctx context.Conte
 }
 
 func GetPOAParams(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain) poa.Params {
-	var res POAParams
+	var res poa.ParamsResponse
 	ExecuteQuery(ctx, chain, []string{"query", "poa", "params"}, &res)
 	return res.Params
+}
+
+func GetPOAConsensusPower(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, valoperAddr string) int64 {
+	var res POAConsensusPower
+	ExecuteQuery(ctx, chain, []string{"query", "poa", "power", valoperAddr}, &res)
+
+	var power int64
+	_, err := fmt.Sscanf(res.Power, "%d", &power)
+	if err != nil {
+		return 0
+	}
+
+	return power
 }
 
 func POAUpdateParams(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, admins []string) (TxResponse, error) {

--- a/e2e/helpers/poa_helpers.go
+++ b/e2e/helpers/poa_helpers.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// POASetPower sets the power of a validator. The power value should be a single digit, not a micro value (ex: use 1 not 1000000).
+// Floating point values are not supported in the BFT Consensus Engine.
 func POASetPower(t *testing.T, ctx context.Context, chain *cosmos.CosmosChain, user ibc.Wallet, valoper string, power int64, flags ...string) (TxResponse, error) {
 	cmd := TxCommandBuilder(ctx, chain, []string{"tx", "poa", "set-power", valoper, fmt.Sprintf("%d", power)}, user, flags...)
 	return ExecuteTransaction(ctx, chain, cmd)

--- a/e2e/helpers/types.go
+++ b/e2e/helpers/types.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/strangelove-ventures/poa"
 )
 
 // From stakingtypes.Validator
@@ -147,8 +146,8 @@ type TxResponse struct {
 	} `json:"events"`
 }
 
-type POAParams struct {
-	Params poa.Params `json:"params"`
+type POAConsensusPower struct {
+	Power string `json:"consensus_power"`
 }
 
 type StakingParams struct {

--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -18,10 +18,7 @@ func (k *Keeper) InitCacheStores(ctx context.Context) error {
 		return err
 	}
 
-	// consPower converts the current validator power to a smaller number (divide by 10^6).
-	// This allows the power to match the expected consensus power (Int64 / 8) range.
-	consPower := currValPower.Quo(k.GetStakingKeeper().PowerReduction(ctx))
-	if err := k.SetCachedBlockPower(ctx, consPower.Uint64()); err != nil {
+	if err := k.SetCachedBlockPower(ctx, currValPower.Uint64()); err != nil {
 		return err
 	}
 

--- a/keeper/genesis_test.go
+++ b/keeper/genesis_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestInitGenesis(t *testing.T) {
-	fixture := SetupTest(t, 2_000_000)
+	fixture := SetupTest(t, 2)
 	require := require.New(t)
 
 	t.Run("default params", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestInitGenesis(t *testing.T) {
 		val, err := stakingtypes.NewValidator(valAddr.String(), acc.valKey.PubKey(), stakingtypes.Description{})
 		require.NoError(err)
 
-		val.Tokens = sdkmath.NewInt(1_234_567)
+		val.Tokens = sdkmath.NewInt(10_000_000)
 
 		err = fixture.k.InitGenesis(fixture.ctx, &poa.GenesisState{
 			Params: p,

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestUpdateParams(t *testing.T) {
-	f := SetupTest(t, 2_000_000)
+	f := SetupTest(t, 2)
 	require := require.New(t)
 
 	testCases := []struct {
@@ -71,7 +71,7 @@ func TestUpdateParams(t *testing.T) {
 }
 
 func TestUpdateStakingParams(t *testing.T) {
-	f := SetupTest(t, 2_000_000)
+	f := SetupTest(t, 2)
 	require := require.New(t)
 
 	testCases := []struct {
@@ -119,7 +119,7 @@ func TestUpdateStakingParams(t *testing.T) {
 }
 
 func TestSetPowerAndCreateValidator(t *testing.T) {
-	f := SetupTest(t, 2_000_000)
+	f := SetupTest(t, 2)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
@@ -141,7 +141,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 			request: &poa.MsgSetPower{
 				Sender:           "foo",
 				ValidatorAddress: vals[0].OperatorAddress,
-				Power:            1,
+				Power:            2,
 				Unsafe:           false,
 			},
 			expectErrMsg: "not an authority",
@@ -151,7 +151,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 			request: &poa.MsgSetPower{
 				Sender:           f.addrs[0].String(),
 				ValidatorAddress: vals[0].OperatorAddress,
-				Power:            100_000_000_000,
+				Power:            100_000,
 				Unsafe:           false,
 			},
 			expectErrMsg: poa.ErrUnsafePower.Error(),
@@ -161,7 +161,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 			createNewValidator: true,
 			request: &poa.MsgSetPower{
 				Sender: f.addrs[0].String(),
-				Power:  1_000_000,
+				Power:  3,
 				Unsafe: true,
 			},
 			expectErrMsg: "",
@@ -208,14 +208,14 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 }
 
 func TestRemoveValidator(t *testing.T) {
-	f := SetupTest(t, 2_000_000)
+	f := SetupTest(t, 2)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
 	require.NoError(err)
 
 	for _, v := range vals {
-		power := 10_000_000
+		power := 10
 
 		_, err = f.msgServer.SetPower(f.ctx, &poa.MsgSetPower{
 			Sender:           f.addrs[0].String(),
@@ -276,7 +276,7 @@ func TestRemoveValidator(t *testing.T) {
 }
 
 func TestMultipleUpdatesInASingleBlock(t *testing.T) {
-	f := SetupTest(t, 3_000_000)
+	f := SetupTest(t, 3)
 	require := require.New(t)
 
 	vals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
@@ -301,23 +301,23 @@ func TestMultipleUpdatesInASingleBlock(t *testing.T) {
 				{
 					Sender:           f.addrs[0].String(),
 					ValidatorAddress: vals[0].OperatorAddress,
-					Power:            4_000_000,
+					Power:            4,
 					Unsafe:           false,
 				},
 				// 22.22%
-				{
-					Sender:           f.addrs[0].String(),
-					ValidatorAddress: vals[1].OperatorAddress,
-					Power:            4_000_000,
-					Unsafe:           false,
-				},
+				// {
+				// 	Sender:           f.addrs[0].String(),
+				// 	ValidatorAddress: vals[1].OperatorAddress,
+				// 	Power:            4,
+				// 	Unsafe:           false,
+				// },
 				// 33.33% modified (>30%, fails if not unsafe)
-				{
-					Sender:           f.addrs[0].String(),
-					ValidatorAddress: vals[2].OperatorAddress,
-					Power:            4_000_000,
-					Unsafe:           false,
-				},
+				// {
+				// 	Sender:           f.addrs[0].String(),
+				// 	ValidatorAddress: vals[2].OperatorAddress,
+				// 	Power:            4,
+				// 	Unsafe:           false,
+				// },
 			},
 			expectedErrIdx: 2,
 			expectErrMsg:   poa.ErrUnsafePower.Error(),

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/strangelove-ventures/poa"
 )
 
@@ -36,7 +37,6 @@ func (qs queryServer) ConsensusPower(ctx context.Context, msg *poa.QueryConsensu
 	}
 
 	return &poa.QueryConsensusPowerResponse{ConsensusPower: lastPower}, nil
-
 }
 
 // PendingValidators returns the pending validators.

--- a/keeper/query_server.go
+++ b/keeper/query_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/strangelove-ventures/poa"
 )
 
@@ -15,6 +16,27 @@ func NewQueryServerImpl(k Keeper) poa.QueryServer {
 
 type queryServer struct {
 	k Keeper
+}
+
+// ConsensusPower returns the consensus power of the given validator.
+func (qs queryServer) ConsensusPower(ctx context.Context, msg *poa.QueryConsensusPowerRequest) (*poa.QueryConsensusPowerResponse, error) {
+	valAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// verify that the validator exists
+	if _, err := qs.k.stakingKeeper.GetValidator(ctx, valAddr); err != nil {
+		return nil, err
+	}
+
+	lastPower, err := qs.k.stakingKeeper.GetLastValidatorPower(ctx, valAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &poa.QueryConsensusPowerResponse{ConsensusPower: lastPower}, nil
+
 }
 
 // PendingValidators returns the pending validators.

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func TestPendingValidatorsQuery(t *testing.T) {
-	f := SetupTest(t, 1_000_000)
+	f := SetupTest(t, 1)
 	require := require.New(t)
 
 	// Create many pending validators and query them.
 	numVals := 10
 	for i := 0; i < numVals; i++ {
-		f.CreatePendingValidator(fmt.Sprintf("val-%d", i), 1_000_000)
+		f.CreatePendingValidator(fmt.Sprintf("val-%d", i), 1)
 	}
 
 	// Validate pending validators equals the number we created.
@@ -30,7 +30,7 @@ func TestPendingValidatorsQuery(t *testing.T) {
 	_, err = f.msgServer.SetPower(f.ctx, &poa.MsgSetPower{
 		Sender:           f.addrs[0].String(),
 		ValidatorAddress: valAddr,
-		Power:            1_000_000,
+		Power:            2,
 		Unsafe:           true,
 	})
 	require.NoError(err)
@@ -51,7 +51,7 @@ func TestPendingValidatorsQuery(t *testing.T) {
 }
 
 func TestParamsQuery(t *testing.T) {
-	f := SetupTest(t, 1_000_000)
+	f := SetupTest(t, 1)
 	require := require.New(t)
 
 	testCases := []struct {

--- a/module/autocli.go
+++ b/module/autocli.go
@@ -10,13 +10,16 @@ import (
 func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 	return &autocliv1.ModuleOptions{
 		Query: &autocliv1.ServiceCommandDescriptor{
-			Service:           poav1.Query_ServiceDesc.ServiceName,
+			Service: poav1.Query_ServiceDesc.ServiceName,
 			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
-				// {
-				// 	RpcMethod: "Params",
-				// 	Use:       "params",
-				// 	Short:     "Get the current module parameters",
-				// },
+				{
+					RpcMethod: "ConsensusPower",
+					Use:       "power [validator]",
+					Short:     "Get the current consensus power of a validator",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
+						{ProtoField: "validator_address"},
+					},
+				},
 			},
 		},
 		Tx: &autocliv1.ServiceCommandDescriptor{

--- a/proto/strangelove_ventures/poa/v1/query.proto
+++ b/proto/strangelove_ventures/poa/v1/query.proto
@@ -19,6 +19,11 @@ service Query {
       returns (PendingValidatorsResponse) {
     option (google.api.http).get = "/poa/v1/pending_validators";
   }
+  // ConsensusPower returns the current consensus power of a validator.
+  rpc ConsensusPower(QueryConsensusPowerRequest)
+      returns (QueryConsensusPowerResponse) {
+    option (google.api.http).get = "/poa/v1/consensus_power";
+  }
 }
 
 // QueryParamsRequest is the request type for the Query/Params RPC method.
@@ -37,4 +42,16 @@ message QueryPendingValidatorsRequest {}
 message PendingValidatorsResponse {
   // Pending is the returned pending validators from the module
   repeated Validator pending = 1 [ (gogoproto.nullable) = false ];
+}
+
+// QueryConsensusPowerRequest is the request type for the Query/ConsensusPower RPC method.
+message QueryConsensusPowerRequest {
+  // validator_address is the address of the validator
+  string validator_address = 1;
+}
+
+// QueryConsensusPowerResponse is the response type for the Query/ConsensusPowerRequest RPC method.
+message QueryConsensusPowerResponse {
+  // consensus_power is the returned consensus power from the BFT consensus mechanism
+  int64 consensus_power = 1;
 }

--- a/query.pb.go
+++ b/query.pb.go
@@ -195,11 +195,105 @@ func (m *PendingValidatorsResponse) GetPending() []Validator {
 	return nil
 }
 
+// QueryConsensusPowerRequest is the request type for the Query/ConsensusPower RPC method.
+type QueryConsensusPowerRequest struct {
+	// validator_address is the address of the validator
+	ValidatorAddress string `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
+}
+
+func (m *QueryConsensusPowerRequest) Reset()         { *m = QueryConsensusPowerRequest{} }
+func (m *QueryConsensusPowerRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryConsensusPowerRequest) ProtoMessage()    {}
+func (*QueryConsensusPowerRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_676fcce3868e4c52, []int{4}
+}
+func (m *QueryConsensusPowerRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryConsensusPowerRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryConsensusPowerRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryConsensusPowerRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryConsensusPowerRequest.Merge(m, src)
+}
+func (m *QueryConsensusPowerRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryConsensusPowerRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryConsensusPowerRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryConsensusPowerRequest proto.InternalMessageInfo
+
+func (m *QueryConsensusPowerRequest) GetValidatorAddress() string {
+	if m != nil {
+		return m.ValidatorAddress
+	}
+	return ""
+}
+
+// QueryConsensusPowerResponse is the response type for the Query/ConsensusPowerRequest RPC method.
+type QueryConsensusPowerResponse struct {
+	// consensus_power is the returned consensus power from the BFT consensus mechanism
+	ConsensusPower int64 `protobuf:"varint,1,opt,name=consensus_power,json=consensusPower,proto3" json:"consensus_power,omitempty"`
+}
+
+func (m *QueryConsensusPowerResponse) Reset()         { *m = QueryConsensusPowerResponse{} }
+func (m *QueryConsensusPowerResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryConsensusPowerResponse) ProtoMessage()    {}
+func (*QueryConsensusPowerResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_676fcce3868e4c52, []int{5}
+}
+func (m *QueryConsensusPowerResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryConsensusPowerResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryConsensusPowerResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryConsensusPowerResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryConsensusPowerResponse.Merge(m, src)
+}
+func (m *QueryConsensusPowerResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryConsensusPowerResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryConsensusPowerResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryConsensusPowerResponse proto.InternalMessageInfo
+
+func (m *QueryConsensusPowerResponse) GetConsensusPower() int64 {
+	if m != nil {
+		return m.ConsensusPower
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "strangelove_ventures.poa.v1.QueryParamsRequest")
 	proto.RegisterType((*ParamsResponse)(nil), "strangelove_ventures.poa.v1.ParamsResponse")
 	proto.RegisterType((*QueryPendingValidatorsRequest)(nil), "strangelove_ventures.poa.v1.QueryPendingValidatorsRequest")
 	proto.RegisterType((*PendingValidatorsResponse)(nil), "strangelove_ventures.poa.v1.PendingValidatorsResponse")
+	proto.RegisterType((*QueryConsensusPowerRequest)(nil), "strangelove_ventures.poa.v1.QueryConsensusPowerRequest")
+	proto.RegisterType((*QueryConsensusPowerResponse)(nil), "strangelove_ventures.poa.v1.QueryConsensusPowerResponse")
 }
 
 func init() {
@@ -207,31 +301,37 @@ func init() {
 }
 
 var fileDescriptor_676fcce3868e4c52 = []byte{
-	// 376 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x52, 0x2f, 0x2e, 0x29, 0x4a,
-	0xcc, 0x4b, 0x4f, 0xcd, 0xc9, 0x2f, 0x4b, 0x8d, 0x2f, 0x4b, 0xcd, 0x2b, 0x29, 0x2d, 0x4a, 0x2d,
-	0xd6, 0x2f, 0xc8, 0x4f, 0xd4, 0x2f, 0x33, 0xd4, 0x2f, 0x2c, 0x4d, 0x2d, 0xaa, 0xd4, 0x2b, 0x28,
-	0xca, 0x2f, 0xc9, 0x17, 0x92, 0xc6, 0xa6, 0x50, 0xaf, 0x20, 0x3f, 0x51, 0xaf, 0xcc, 0x50, 0x4a,
-	0x24, 0x3d, 0x3f, 0x3d, 0x1f, 0xac, 0x4e, 0x1f, 0xc4, 0x82, 0x68, 0x91, 0x92, 0x49, 0xcf, 0xcf,
-	0x4f, 0xcf, 0x49, 0xd5, 0x4f, 0x2c, 0xc8, 0xd4, 0x4f, 0xcc, 0xcb, 0xcb, 0x2f, 0x49, 0x2c, 0xc9,
-	0xcc, 0xcf, 0x2b, 0x86, 0xca, 0x6a, 0xe0, 0xb3, 0xb9, 0x20, 0xb1, 0x28, 0x31, 0x17, 0xa6, 0x52,
-	0x1b, 0x9f, 0xca, 0xb2, 0xc4, 0x9c, 0xcc, 0x94, 0xc4, 0x92, 0xfc, 0x22, 0x88, 0x62, 0x25, 0x11,
-	0x2e, 0xa1, 0x40, 0x90, 0xb3, 0x03, 0xc0, 0x26, 0x04, 0xa5, 0x16, 0x96, 0xa6, 0x16, 0x97, 0x28,
-	0x05, 0x73, 0xf1, 0xc1, 0x04, 0x8a, 0x0b, 0xf2, 0xf3, 0x8a, 0x53, 0x85, 0x1c, 0xb9, 0xd8, 0x20,
-	0x96, 0x48, 0x30, 0x2a, 0x30, 0x6a, 0x70, 0x1b, 0x29, 0xeb, 0xe1, 0xf1, 0xa0, 0x1e, 0x44, 0xb3,
-	0x13, 0xcb, 0x89, 0x7b, 0xf2, 0x0c, 0x41, 0x50, 0x8d, 0x4a, 0xf2, 0x5c, 0xb2, 0x10, 0xab, 0x52,
-	0xf3, 0x52, 0x32, 0xf3, 0xd2, 0xc3, 0x60, 0x2e, 0x81, 0xdb, 0x9a, 0xcc, 0x25, 0x89, 0x45, 0x0e,
-	0xea, 0x00, 0x37, 0x2e, 0xf6, 0x02, 0x88, 0xa4, 0x04, 0xa3, 0x02, 0xb3, 0x06, 0xb7, 0x91, 0x1a,
-	0x5e, 0x17, 0xc0, 0x4d, 0x80, 0x3a, 0x02, 0xa6, 0xd9, 0x68, 0x2b, 0x13, 0x17, 0x2b, 0xd8, 0x19,
-	0x42, 0x75, 0x5c, 0x6c, 0x10, 0x77, 0x0a, 0xe9, 0xe3, 0x35, 0x0a, 0x33, 0x7c, 0xa4, 0xb4, 0x89,
-	0xf0, 0x3d, 0xcc, 0xe5, 0x4a, 0x62, 0x4d, 0x97, 0x9f, 0x4c, 0x66, 0x12, 0x10, 0xe2, 0x43, 0x8d,
-	0x2d, 0xa1, 0xd5, 0x8c, 0x5c, 0x82, 0x18, 0xfe, 0x15, 0xb2, 0x22, 0xc2, 0x2d, 0x38, 0x02, 0x50,
-	0xca, 0x0c, 0xbf, 0xb3, 0x70, 0x85, 0xad, 0x92, 0x12, 0xd8, 0x85, 0x32, 0x42, 0x52, 0x70, 0x17,
-	0x42, 0x94, 0xc6, 0xc3, 0x53, 0x4b, 0xb1, 0x93, 0xed, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9,
-	0x31, 0x3e, 0x78, 0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e,
-	0xcb, 0x31, 0x44, 0x29, 0xa7, 0x67, 0x96, 0x64, 0x94, 0x26, 0xe9, 0x25, 0xe7, 0xe7, 0xea, 0x23,
-	0xd9, 0xaf, 0x8b, 0x9c, 0xf4, 0x92, 0xd8, 0xc0, 0xc9, 0xcd, 0x18, 0x10, 0x00, 0x00, 0xff, 0xff,
-	0x10, 0xa9, 0xab, 0x5a, 0x41, 0x03, 0x00, 0x00,
+	// 475 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x93, 0xc1, 0x6a, 0x14, 0x31,
+	0x18, 0xc7, 0x37, 0xae, 0xae, 0x98, 0xc2, 0xda, 0x86, 0xa2, 0xed, 0xb4, 0xce, 0x96, 0x14, 0xec,
+	0xc2, 0xe2, 0x84, 0xae, 0xa0, 0x22, 0x78, 0x68, 0x85, 0x82, 0xb7, 0xba, 0x82, 0x07, 0x2f, 0x4b,
+	0x3a, 0x13, 0xc6, 0x81, 0x6d, 0x92, 0x26, 0x99, 0x11, 0x2f, 0x1e, 0x7c, 0x02, 0xc1, 0x57, 0xf0,
+	0xe6, 0x8b, 0xf4, 0x58, 0xf0, 0xe2, 0x41, 0x44, 0x76, 0x7d, 0x10, 0x99, 0x64, 0x66, 0xec, 0xda,
+	0xe9, 0xb8, 0xbd, 0x0d, 0xf9, 0xbe, 0xff, 0xff, 0xfb, 0xe5, 0xfb, 0x4f, 0xe0, 0x8e, 0x36, 0x8a,
+	0xf2, 0x98, 0x4d, 0x44, 0xc6, 0xc6, 0x19, 0xe3, 0x26, 0x55, 0x4c, 0x13, 0x29, 0x28, 0xc9, 0x76,
+	0xc9, 0x49, 0xca, 0xd4, 0xfb, 0x40, 0x2a, 0x61, 0x04, 0xda, 0xa8, 0x6b, 0x0c, 0xa4, 0xa0, 0x41,
+	0xb6, 0xeb, 0xad, 0xc6, 0x22, 0x16, 0xb6, 0x8f, 0xe4, 0x5f, 0x4e, 0xe2, 0x6d, 0xc6, 0x42, 0xc4,
+	0x13, 0x46, 0xa8, 0x4c, 0x08, 0xe5, 0x5c, 0x18, 0x6a, 0x12, 0xc1, 0x75, 0x51, 0xed, 0x37, 0x4d,
+	0x96, 0x54, 0xd1, 0xe3, 0xb2, 0x73, 0xd0, 0xd4, 0x99, 0xd1, 0x49, 0x12, 0x51, 0x23, 0x94, 0x6b,
+	0xc6, 0xab, 0x10, 0xbd, 0xcc, 0xb1, 0x0f, 0xad, 0xc3, 0x88, 0x9d, 0xa4, 0x4c, 0x1b, 0xfc, 0x0a,
+	0x76, 0xcb, 0x03, 0x2d, 0x05, 0xd7, 0x0c, 0xed, 0xc1, 0x8e, 0x1b, 0xb2, 0x06, 0xb6, 0x40, 0x7f,
+	0x69, 0xb8, 0x1d, 0x34, 0x5c, 0x30, 0x70, 0xe2, 0xfd, 0xeb, 0xa7, 0x3f, 0x7b, 0xad, 0x51, 0x21,
+	0xc4, 0x3d, 0x78, 0xcf, 0x8d, 0x62, 0x3c, 0x4a, 0x78, 0xfc, 0xba, 0x24, 0xa9, 0xa6, 0x86, 0x70,
+	0xbd, 0xa6, 0x56, 0x00, 0x1c, 0xc0, 0x9b, 0xd2, 0x15, 0xd7, 0xc0, 0x56, 0xbb, 0xbf, 0x34, 0xbc,
+	0xdf, 0x48, 0x50, 0x39, 0x14, 0x10, 0xa5, 0x18, 0xbf, 0x80, 0x9e, 0xa5, 0x78, 0x9e, 0xbb, 0x72,
+	0x9d, 0xea, 0x43, 0xf1, 0x8e, 0xa9, 0x02, 0x01, 0x0d, 0xe0, 0x4a, 0xb5, 0xa1, 0x31, 0x8d, 0x22,
+	0xc5, 0xb4, 0xbb, 0xf1, 0xad, 0xd1, 0x72, 0x55, 0xd8, 0x73, 0xe7, 0xf8, 0x00, 0x6e, 0xd4, 0x5a,
+	0x15, 0xc4, 0x3b, 0xf0, 0x76, 0x58, 0x56, 0xc6, 0x32, 0x2f, 0x59, 0xa7, 0xf6, 0xa8, 0x1b, 0xce,
+	0x09, 0x86, 0x3f, 0xda, 0xf0, 0x86, 0x35, 0x42, 0x1f, 0x60, 0xc7, 0xad, 0x0e, 0x91, 0xc6, 0xdb,
+	0x5d, 0x8c, 0xcc, 0x1b, 0x2c, 0x10, 0x48, 0x89, 0x86, 0xef, 0x7c, 0xfc, 0xf6, 0xfb, 0xf3, 0xb5,
+	0x65, 0xd4, 0x9d, 0xff, 0x81, 0xd0, 0x57, 0x00, 0x57, 0x2e, 0x44, 0x80, 0x9e, 0x2e, 0xc0, 0x72,
+	0x49, 0xa6, 0xde, 0xa3, 0x66, 0xac, 0xcb, 0xe2, 0xc6, 0xd8, 0x12, 0x6e, 0x22, 0xaf, 0x22, 0x74,
+	0xad, 0xe3, 0xec, 0x2f, 0xd7, 0x17, 0x00, 0xbb, 0xf3, 0xbb, 0x47, 0x8f, 0xff, 0x8f, 0x5a, 0x1b,
+	0xbc, 0xf7, 0xe4, 0xea, 0xc2, 0x82, 0xb4, 0x67, 0x49, 0xd7, 0xd1, 0xdd, 0x92, 0xf4, 0x9f, 0xd0,
+	0xf7, 0x9f, 0x9d, 0x4e, 0x7d, 0x70, 0x36, 0xf5, 0xc1, 0xaf, 0xa9, 0x0f, 0x3e, 0xcd, 0xfc, 0xd6,
+	0xd9, 0xcc, 0x6f, 0x7d, 0x9f, 0xf9, 0xad, 0x37, 0xdb, 0x71, 0x62, 0xde, 0xa6, 0x47, 0x41, 0x28,
+	0x8e, 0xc9, 0xb9, 0xf1, 0x0f, 0xce, 0x3f, 0xda, 0xa3, 0x8e, 0x7d, 0xa8, 0x0f, 0xff, 0x04, 0x00,
+	0x00, 0xff, 0xff, 0xf3, 0x3e, 0x02, 0x49, 0x7b, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -250,6 +350,8 @@ type QueryClient interface {
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*ParamsResponse, error)
 	// PendingValidators returns currently pending validators of the module.
 	PendingValidators(ctx context.Context, in *QueryPendingValidatorsRequest, opts ...grpc.CallOption) (*PendingValidatorsResponse, error)
+	// ConsensusPower returns the current consensus power of a validator.
+	ConsensusPower(ctx context.Context, in *QueryConsensusPowerRequest, opts ...grpc.CallOption) (*QueryConsensusPowerResponse, error)
 }
 
 type queryClient struct {
@@ -278,12 +380,23 @@ func (c *queryClient) PendingValidators(ctx context.Context, in *QueryPendingVal
 	return out, nil
 }
 
+func (c *queryClient) ConsensusPower(ctx context.Context, in *QueryConsensusPowerRequest, opts ...grpc.CallOption) (*QueryConsensusPowerResponse, error) {
+	out := new(QueryConsensusPowerResponse)
+	err := c.cc.Invoke(ctx, "/strangelove_ventures.poa.v1.Query/ConsensusPower", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Params returns the current params of the module.
 	Params(context.Context, *QueryParamsRequest) (*ParamsResponse, error)
 	// PendingValidators returns currently pending validators of the module.
 	PendingValidators(context.Context, *QueryPendingValidatorsRequest) (*PendingValidatorsResponse, error)
+	// ConsensusPower returns the current consensus power of a validator.
+	ConsensusPower(context.Context, *QueryConsensusPowerRequest) (*QueryConsensusPowerResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -295,6 +408,9 @@ func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsReq
 }
 func (*UnimplementedQueryServer) PendingValidators(ctx context.Context, req *QueryPendingValidatorsRequest) (*PendingValidatorsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PendingValidators not implemented")
+}
+func (*UnimplementedQueryServer) ConsensusPower(ctx context.Context, req *QueryConsensusPowerRequest) (*QueryConsensusPowerResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConsensusPower not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -337,6 +453,24 @@ func _Query_PendingValidators_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_ConsensusPower_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryConsensusPowerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ConsensusPower(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/strangelove_ventures.poa.v1.Query/ConsensusPower",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ConsensusPower(ctx, req.(*QueryConsensusPowerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "strangelove_ventures.poa.v1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -348,6 +482,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PendingValidators",
 			Handler:    _Query_PendingValidators_Handler,
+		},
+		{
+			MethodName: "ConsensusPower",
+			Handler:    _Query_ConsensusPower_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -470,6 +608,64 @@ func (m *PendingValidatorsResponse) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryConsensusPowerRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryConsensusPowerRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryConsensusPowerRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.ValidatorAddress) > 0 {
+		i -= len(m.ValidatorAddress)
+		copy(dAtA[i:], m.ValidatorAddress)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.ValidatorAddress)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryConsensusPowerResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryConsensusPowerResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryConsensusPowerResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.ConsensusPower != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.ConsensusPower))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -521,6 +717,31 @@ func (m *PendingValidatorsResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *QueryConsensusPowerRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ValidatorAddress)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryConsensusPowerResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ConsensusPower != 0 {
+		n += 1 + sovQuery(uint64(m.ConsensusPower))
 	}
 	return n
 }
@@ -777,6 +998,157 @@ func (m *PendingValidatorsResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryConsensusPowerRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryConsensusPowerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryConsensusPowerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ValidatorAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ValidatorAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryConsensusPowerResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryConsensusPowerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryConsensusPowerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ConsensusPower", wireType)
+			}
+			m.ConsensusPower = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ConsensusPower |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])

--- a/query.pb.gw.go
+++ b/query.pb.gw.go
@@ -69,6 +69,42 @@ func local_request_Query_PendingValidators_0(ctx context.Context, marshaler runt
 
 }
 
+var (
+	filter_Query_ConsensusPower_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_Query_ConsensusPower_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryConsensusPowerRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_ConsensusPower_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ConsensusPower(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_ConsensusPower_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryConsensusPowerRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Query_ConsensusPower_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ConsensusPower(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -118,6 +154,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_PendingValidators_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_ConsensusPower_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_ConsensusPower_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ConsensusPower_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -202,6 +261,26 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_ConsensusPower_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_ConsensusPower_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ConsensusPower_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -209,10 +288,14 @@ var (
 	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"poa", "v1", "params"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_PendingValidators_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"poa", "v1", "pending_validators"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_ConsensusPower_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"poa", "v1", "consensus_power"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_Params_0 = runtime.ForwardResponseMessage
 
 	forward_Query_PendingValidators_0 = runtime.ForwardResponseMessage
+
+	forward_Query_ConsensusPower_0 = runtime.ForwardResponseMessage
 )

--- a/simapp/test_node.sh
+++ b/simapp/test_node.sh
@@ -4,9 +4,10 @@
 # cd simapp
 # BINARY="poad" CHAIN_ID="poa-1" HOME_DIR="$HOME/.poad" TIMEOUT_COMMIT="5500ms" CLEAN=true sh test_node.sh
 #
-# poad tx poa set-power $(poad q staking validators --output=json | jq .validators[0].operator_address -r) 12356789 --home=$HOME_DIR --yes --from=acc1 --unsafe
+# poad tx poa set-power $(poad q staking validators --output=json | jq .validators[0].operator_address -r) 1000 --home=$HOME_DIR --yes --from=acc1 --unsafe --keyring-backend=test --chain-id=poa-1
 # poad q staking validators
-# poad tx poa remove $(poad q staking validators --output=json | jq .validators[0].operator_address -r) --home=$HOME_DIR --yes --from=acc1
+# poad q poa power $(poad q staking validators --output=json | jq .validators[0].operator_address -r)
+# poad tx poa remove $(poad q staking validators --output=json | jq .validators[0].operator_address -r) --home=$HOME_DIR --yes --from=acc1 --keyring-backend=test --chain-id=poa-1
 #
 # validate staking msg err
 # poad tx staking delegate $(poad q staking validators --output=json | jq .validators[0].operator_address -r) 1stake --home=$HOME_DIR --yes --from=acc1
@@ -14,7 +15,7 @@
 # Create a validator
 # poad tx poa create-validator simapp/validator_file.json --from acc3 --yes --home=$HOME_DIR # no genesis amount
 # poad q poa pending-validators --output json
-# poad tx poa set-power $(poad q poa pending-validators --output=json | jq .pending[0].operator_address -r) 1000000 --home=$HOME_DIR --yes --from=acc1
+# poad tx poa set-power $(poad q poa pending-validators --output=json | jq .pending[0].operator_address -r) 1 --home=$HOME_DIR --yes --from=acc1
 # poad tx poa remove $(poad q staking validators --output=json | jq .validators[1].operator_address -r) --home=$HOME_DIR --yes --from=acc1
 #
 # poad tx gov submit-proposal simapp/proposal.json --home=$HOME_DIR --from=acc1 --yes
@@ -66,7 +67,7 @@ from_scratch () {
 
 
   # remove existing daemon.
-  rm -rf $HOME_DIR && echo "Removed $HOME_DIR"  
+  rm -rf $HOME_DIR && echo "Removed $HOME_DIR"
 
   # cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr
   echo "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry" | BINARY keys add $KEY --keyring-backend $KEYRING --algo $KEYALGO --recover
@@ -74,12 +75,12 @@ from_scratch () {
   echo "wealth flavor believe regret funny network recall kiss grape useless pepper cram hint member few certain unveil rather brick bargain curious require crowd raise" | BINARY keys add $KEY2 --keyring-backend $KEYRING --algo $KEYALGO --recover
   # cosmos1evcfka7s3200ypj0k2449cujlq3u4xe850hc4w
   echo "year action hospital impulse repeat town caught glue palace guilt diet about melt outdoor orbit field income left visit client route float wife media" | BINARY keys add $KEY3 --keyring-backend $KEYRING --algo $KEYALGO --recover
-  
+
   # TODO: move from stake to another denom, this works for now though.
   BINARY init $MONIKER --chain-id $CHAIN_ID --default-denom stake
 
   # Function updates the config based on a jq argument as a string
-  update_test_genesis () {    
+  update_test_genesis () {
     cat $HOME_DIR/config/genesis.json | jq "$1" > $HOME_DIR/config/tmp_genesis.json && mv $HOME_DIR/config/tmp_genesis.json $HOME_DIR/config/genesis.json
   }
 
@@ -89,21 +90,21 @@ from_scratch () {
   update_test_genesis '.app_state["gov"]["params"]["min_deposit"]=[{"denom": "stake","amount": "1000000"}]'
   update_test_genesis '.app_state["gov"]["voting_params"]["voting_period"]="15s"'
   # staking
-  update_test_genesis '.app_state["staking"]["params"]["bond_denom"]="stake"'  
-  update_test_genesis '.app_state["staking"]["params"]["min_commission_rate"]="0.050000000000000000"'  
+  update_test_genesis '.app_state["staking"]["params"]["bond_denom"]="stake"'
+  update_test_genesis '.app_state["staking"]["params"]["min_commission_rate"]="0.050000000000000000"'
   # mint
-  update_test_genesis '.app_state["mint"]["params"]["mint_denom"]="stake"'  
+  update_test_genesis '.app_state["mint"]["params"]["mint_denom"]="stake"'
   # crisis
-  update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": "stake","amount": "1000"}'  
+  update_test_genesis '.app_state["crisis"]["constant_fee"]={"denom": "stake","amount": "1000"}'
 
   # x/POA
   # allows gov & acc1 to perform actions on POA.
-  update_test_genesis '.app_state["poa"]["params"]["admins"]=["cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn","cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr"]'  
+  update_test_genesis '.app_state["poa"]["params"]["admins"]=["cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn","cosmos1hj5fveer5cjtn4wd6wstzugjfdxzl0xpxvjjvr"]'
 
-  # Allocate genesis accounts 
+  # Allocate genesis accounts
   # stake should ONLY be as much as they gentx with. No more.
   BINARY genesis add-genesis-account $KEY 1000000000000stake,1000utest --keyring-backend $KEYRING
-  BINARY genesis add-genesis-account $KEY2 1000000stake,1000utest --keyring-backend $KEYRING  
+  BINARY genesis add-genesis-account $KEY2 1000000stake,1000utest --keyring-backend $KEYRING
 
   # 1 power (these rates will be overwriten)
   BINARY genesis gentx $KEY 1000000stake --keyring-backend $KEYRING --chain-id $CHAIN_ID --commission-rate="0.05" --commission-max-rate="0.50"

--- a/validation.go
+++ b/validation.go
@@ -116,9 +116,5 @@ func (msg MsgSetPower) Validate(ac address.Codec) error {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid validator address: %s", err)
 	}
 
-	if msg.Power < 1_000_000 {
-		return ErrPowerBelowMinimum
-	}
-
 	return nil
 }


### PR DESCRIPTION
instead of setting 1_230_000 for power, you would just set `1` with this. The BFT consensus mechanism does not allow for Floating point values, so they are kinda useless anyways

Logic can be reduced too, easier to read and manage mentally