### PR TITLE
feat!: Transfer PoA admin via bank denom

### DIFF
--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -166,7 +166,6 @@ func registerBaseSDKModules(
 	require.NoError(err)
 
 	// Mint Keeper.
-	// This is required for `MintTokensToBondedPool` to remain happy.
 	f.mintkeeper = mintkeeper.NewKeeper(
 		encCfg.Codec, storeService,
 		f.stakingKeeper, f.accountkeeper, f.bankkeeper,

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -286,7 +286,15 @@ func NewSimApp(
 	bApp.SetParamStore(app.ConsensusParamsKeeper.ParamsStore)
 
 	// add keepers
-	app.AccountKeeper = authkeeper.NewAccountKeeper(appCodec, runtime.NewKVStoreService(keys[authtypes.StoreKey]), authtypes.ProtoBaseAccount, maccPerms, authcodec.NewBech32Codec(sdk.Bech32MainPrefix), sdk.Bech32MainPrefix, govModAddress)
+	app.AccountKeeper = authkeeper.NewAccountKeeper(
+		appCodec,
+		runtime.NewKVStoreService(keys[authtypes.StoreKey]),
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix()),
+		sdk.GetConfig().GetBech32AccountAddrPrefix(),
+		govModAddress,
+	)
 
 	app.BankKeeper = bankkeeper.NewBaseKeeper(
 		appCodec,
@@ -297,7 +305,13 @@ func NewSimApp(
 		logger,
 	)
 	app.StakingKeeper = stakingkeeper.NewKeeper(
-		appCodec, runtime.NewKVStoreService(keys[stakingtypes.StoreKey]), app.AccountKeeper, app.BankKeeper, govModAddress, authcodec.NewBech32Codec(sdk.Bech32PrefixValAddr), authcodec.NewBech32Codec(sdk.Bech32PrefixConsAddr),
+		appCodec,
+		runtime.NewKVStoreService(keys[stakingtypes.StoreKey]),
+		app.AccountKeeper,
+		app.BankKeeper,
+		govModAddress,
+		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ConsensusAddrPrefix()),
 	)
 	app.MintKeeper = mintkeeper.NewKeeper(appCodec, runtime.NewKVStoreService(keys[minttypes.StoreKey]), app.StakingKeeper, app.AccountKeeper, app.BankKeeper, authtypes.FeeCollectorName, govModAddress)
 
@@ -320,7 +334,7 @@ func NewSimApp(
 		app.StakingKeeper,
 		app.SlashingKeeper,
 		app.BankKeeper,
-		authcodec.NewBech32Codec(sdk.Bech32PrefixValAddr),
+		authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
 		logger,
 	)
 


### PR DESCRIPTION
closes #112

## Summary
The chain's app.go must opt in by using `poakeeper.SetAdminTokenDenom("denom")` on start to set this on. Only wallets holding the token ("denom" in this case) of any amount, are able to perform admin actions.

## Optional
Using tokenfactory, a denom admin account can be used (i.e. multisig) to handle the distribution & reclaiming from individual accounts. 

## TODO
- Add to integration docs
- Reduce unit test complexity, just use IsAdmin bool check