### PR TITLE
chore: use stakingKeepers validatorCodec instead of freshly defining

### DIFF
--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	addresscodec "cosmossdk.io/core/address"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -12,7 +13,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"cosmossdk.io/collections"
-	addresscodec "cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	sdkmath "cosmossdk.io/math"
@@ -21,8 +21,7 @@ import (
 )
 
 type Keeper struct {
-	cdc                   codec.BinaryCodec
-	validatorAddressCodec addresscodec.Codec
+	cdc codec.BinaryCodec
 
 	stakingKeeper *stakingkeeper.Keeper
 	slashKeeper   SlashingKeeper
@@ -46,7 +45,6 @@ func NewKeeper(
 	sk *stakingkeeper.Keeper,
 	slk SlashingKeeper,
 	bk BankKeeper,
-	validatorAddressCodec addresscodec.Codec,
 	logger log.Logger,
 ) Keeper {
 	logger = logger.With(log.ModuleKey, "x/"+poa.ModuleName)
@@ -54,12 +52,11 @@ func NewKeeper(
 	sb := collections.NewSchemaBuilder(storeService)
 
 	k := Keeper{
-		cdc:                   cdc,
-		stakingKeeper:         sk,
-		validatorAddressCodec: validatorAddressCodec,
-		slashKeeper:           slk,
-		bankKeeper:            bk,
-		logger:                logger,
+		cdc:           cdc,
+		stakingKeeper: sk,
+		slashKeeper:   slk,
+		bankKeeper:    bk,
+		logger:        logger,
 
 		// Stores
 		Params:            collections.NewItem(sb, poa.ParamsKey, "params", codec.CollValue[poa.Params](cdc)),
@@ -82,6 +79,10 @@ func NewKeeper(
 // GetStakingKeeper returns the staking keeper.
 func (k Keeper) GetStakingKeeper() *stakingkeeper.Keeper {
 	return k.stakingKeeper
+}
+
+func (k Keeper) GetValidatorAddressCodec() addresscodec.Codec {
+	return k.stakingKeeper.ValidatorAddressCodec()
 }
 
 // GetSlashingKeeper returns the slashing keeper.

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"context"
 
-	addresscodec "cosmossdk.io/core/address"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -13,6 +12,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"cosmossdk.io/collections"
+	addresscodec "cosmossdk.io/core/address"
 	storetypes "cosmossdk.io/core/store"
 	"cosmossdk.io/log"
 	sdkmath "cosmossdk.io/math"

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -10,7 +10,6 @@ import (
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
-	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -91,7 +90,7 @@ func SetupTest(t *testing.T, baseValShares int64) *testFixture {
 	registerBaseSDKModules(f, encCfg, storeService, logger, require)
 
 	// Setup POA Keeper.
-	f.k = keeper.NewKeeper(encCfg.Codec, storeService, f.stakingKeeper, f.slashingKeeper, f.bankkeeper, addresscodec.NewBech32Codec(sdk.Bech32PrefixValAddr), logger)
+	f.k = keeper.NewKeeper(encCfg.Codec, storeService, f.stakingKeeper, f.slashingKeeper, f.bankkeeper, logger)
 	f.msgServer = keeper.NewMsgServerImpl(f.k)
 	f.queryServer = keeper.NewQueryServerImpl(f.k)
 	f.appModule = poamodule.NewAppModule(encCfg.Codec, f.k)

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -31,7 +31,7 @@ func (ms msgServer) SetPower(ctx context.Context, msg *poa.MsgSetPower) (*poa.Ms
 		return nil, errorsmod.Wrapf(poa.ErrNotAnAuthority, "sender %s is not an authority. allowed: %+v", msg.Sender, ms.k.GetAdmins(ctx))
 	}
 
-	if err := msg.Validate(ms.k.validatorAddressCodec); err != nil {
+	if err := msg.Validate(ms.k.GetValidatorAddressCodec()); err != nil {
 		return nil, err
 	}
 
@@ -172,12 +172,12 @@ func (ms msgServer) UpdateParams(ctx context.Context, msg *poa.MsgUpdateParams) 
 // - Create hook logic removed (this is done after acceptance).
 // - Valiadtor is added to the pending queue (AddPendingValidator).
 func (ms msgServer) CreateValidator(ctx context.Context, msg *poa.MsgCreateValidator) (*poa.MsgCreateValidatorResponse, error) {
-	valAddr, err := ms.k.validatorAddressCodec.StringToBytes(msg.ValidatorAddress)
+	valAddr, err := ms.k.GetValidatorAddressCodec().StringToBytes(msg.ValidatorAddress)
 	if err != nil {
 		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid validator address: %s", err)
 	}
 
-	if err := msg.Validate(ms.k.validatorAddressCodec); err != nil {
+	if err := msg.Validate(ms.k.GetValidatorAddressCodec()); err != nil {
 		return nil, err
 	}
 

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -177,7 +177,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 				// check the pending validators includes the new validator
 				pendingVals, err := f.k.GetPendingValidators(f.ctx)
 				require.NoError(err)
-				require.EqualValues(1, len(pendingVals.Validators))
+				require.Len(pendingVals.Validators, 1)
 			}
 
 			require.NotEmpty(tc.request.ValidatorAddress)
@@ -198,7 +198,7 @@ func TestSetPowerAndCreateValidator(t *testing.T) {
 				postVals, err := f.stakingKeeper.GetValidators(f.ctx, 100)
 				require.NoError(err)
 
-				require.EqualValues(len(preVals)+1, len(postVals))
+				require.Len(postVals, len(preVals)+1)
 			} else {
 				require.EqualValues(len(vals), len(preVals))
 			}
@@ -213,7 +213,7 @@ func TestRemovePending(t *testing.T) {
 	valAddr := f.CreatePendingValidator("val-1", 1_000_000)
 	pendingVals, err := f.k.GetPendingValidators(f.ctx)
 	require.NoError(err)
-	require.EqualValues(1, len(pendingVals.Validators))
+	require.Len(pendingVals.Validators, 1)
 
 	testCases := []struct {
 		name               string
@@ -253,7 +253,7 @@ func TestRemovePending(t *testing.T) {
 
 			pendingVals, err := f.k.GetPendingValidators(f.ctx)
 			require.NoError(err)
-			require.EqualValues(tc.expectedPendingLen, len(pendingVals.Validators))
+			require.Len(pendingVals.Validators, tc.expectedPendingLen)
 		})
 	}
 }

--- a/keeper/poa.go
+++ b/keeper/poa.go
@@ -159,7 +159,7 @@ func (k Keeper) AcceptNewValidator(ctx context.Context, operatingAddress string,
 // - create new power index (no power set yet)
 // - Emit `ValidatorCreated` staking hook
 func (k Keeper) setValidatorInternals(ctx context.Context, val stakingtypes.Validator) error {
-	valAddr, err := k.validatorAddressCodec.StringToBytes(val.OperatorAddress)
+	valAddr, err := k.GetValidatorAddressCodec().StringToBytes(val.OperatorAddress)
 	if err != nil {
 		return sdkerrors.ErrInvalidAddress.Wrapf("invalid validator address: %s", err)
 	}

--- a/keeper/query_server_test.go
+++ b/keeper/query_server_test.go
@@ -22,7 +22,7 @@ func TestPendingValidatorsQuery(t *testing.T) {
 	// Validate pending validators equals the number we created.
 	r, err := f.queryServer.PendingValidators(f.ctx, &poa.QueryPendingValidatorsRequest{})
 	require.NoError(err)
-	require.EqualValues(numVals, len(r.Pending))
+	require.Len(r.Pending, numVals)
 
 	// Accept one of the validators from pending into the active set.
 	valAddr := r.Pending[0].OperatorAddress
@@ -42,7 +42,7 @@ func TestPendingValidatorsQuery(t *testing.T) {
 	// 1 less pending validator.
 	r, err = f.queryServer.PendingValidators(f.ctx, &poa.QueryPendingValidatorsRequest{})
 	require.NoError(err)
-	require.EqualValues(numVals-1, len(r.Pending))
+	require.Len(r.Pending, numVals-1)
 
 	// none of the pending validators should be the one we accepted.
 	for _, val := range r.Pending {

--- a/module/depinject.go
+++ b/module/depinject.go
@@ -53,7 +53,7 @@ type ModuleOutputs struct {
 }
 
 func ProvideModule(in ModuleInputs) ModuleOutputs {
-	k := keeper.NewKeeper(in.Cdc, in.StoreService, &in.StakingKeeper, in.SlashingKeeper, in.BankKeeper, in.AddressCodec, log.NewLogger(os.Stderr))
+	k := keeper.NewKeeper(in.Cdc, in.StoreService, &in.StakingKeeper, in.SlashingKeeper, in.BankKeeper, log.NewLogger(os.Stderr))
 	m := NewAppModule(in.Cdc, k)
 
 	return ModuleOutputs{Module: m, Keeper: k, Out: depinject.Out{}}

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -320,7 +320,6 @@ func NewSimApp(
 		app.StakingKeeper,
 		app.SlashingKeeper,
 		app.BankKeeper,
-		authcodec.NewBech32Codec(sdk.Bech32PrefixValAddr),
 		logger,
 	)
 


### PR DESCRIPTION
## credit
saw in andrew's impl of tiablob, is a good idea rather than redefining (since PoA depends on staking codec anyways)