### PR TITLE
test!: nested msg tests

### DIFF
--- a/ante/disable_staking.go
+++ b/ante/disable_staking.go
@@ -16,49 +16,49 @@ func NewPOADisableStakingDecorator() MsgStakingFilterDecorator {
 }
 
 // AnteHandle performs an AnteHandler check that returns an error if the tx contains a message that is blocked.
-func (msfd MsgStakingFilterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+func (msfd MsgStakingFilterDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	currHeight := ctx.BlockHeight()
 	if currHeight <= 1 {
 		// allow GenTx to pass
 		return next(ctx, tx, simulate)
 	}
 
-	if msfd.hasInvalidStakingMsg(tx.GetMsgs()) {
-		return ctx, poa.ErrStakingActionNotAllowed
+	err := msfd.hasInvalidStakingMsg(tx.GetMsgs())
+	if err != nil {
+		return ctx, err
 	}
 
 	return next(ctx, tx, simulate)
 }
 
-func (msfd MsgStakingFilterDecorator) hasInvalidStakingMsg(msgs []sdk.Msg) bool {
+func (msfd MsgStakingFilterDecorator) hasInvalidStakingMsg(msgs []sdk.Msg) error {
 	for _, msg := range msgs {
 		// authz nested message check (recursive)
 		if execMsg, ok := msg.(*authz.MsgExec); ok {
 			msgs, err := execMsg.GetMessages()
 			if err != nil {
-				return true
+				return err
 			}
 
-			if msfd.hasInvalidStakingMsg(msgs) {
-				return true
+			err = msfd.hasInvalidStakingMsg(msgs)
+			if err != nil {
+				return err
 			}
 		}
 
 		switch msg.(type) {
 		// POA wrapped messages
-		case *stakingtypes.MsgCreateValidator, *stakingtypes.MsgUpdateParams:
-			return true
-
-		// Blocked entirely when POA is enabled
-		case *stakingtypes.MsgBeginRedelegate,
+		case *stakingtypes.MsgCreateValidator, *stakingtypes.MsgUpdateParams,
+			// Blocked entirely when POA is enabled
+			*stakingtypes.MsgBeginRedelegate,
 			*stakingtypes.MsgCancelUnbondingDelegation,
 			*stakingtypes.MsgDelegate,
 			*stakingtypes.MsgUndelegate:
-			return true
+			return poa.ErrStakingActionNotAllowed
 		}
 
 		// stakingtypes.MsgEditValidator is the only allowed message. We do not need to check for it.
 	}
 
-	return false
+	return nil
 }

--- a/ante/disable_withdraw_delegator_rewards.go
+++ b/ante/disable_withdraw_delegator_rewards.go
@@ -15,37 +15,39 @@ func NewPOADisableWithdrawDelegatorRewards() MsgDisableWithdrawDelegatorRewards 
 	return MsgDisableWithdrawDelegatorRewards{}
 }
 
-func (mdwr MsgDisableWithdrawDelegatorRewards) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+func (mdwr MsgDisableWithdrawDelegatorRewards) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	currHeight := ctx.BlockHeight()
 	if currHeight <= 1 {
 		// allow GenTx to pass
 		return next(ctx, tx, simulate)
 	}
 
-	if mdwr.hasWithdrawDelegatorRewardsMsg(tx.GetMsgs()) {
-		return ctx, poa.ErrWithdrawDelegatorRewardsNotAllowed
+	err := mdwr.hasWithdrawDelegatorRewardsMsg(tx.GetMsgs())
+	if err != nil {
+		return ctx, err
 	}
 
 	return next(ctx, tx, simulate)
 }
 
-func (mdwr MsgDisableWithdrawDelegatorRewards) hasWithdrawDelegatorRewardsMsg(msgs []sdk.Msg) bool {
+func (mdwr MsgDisableWithdrawDelegatorRewards) hasWithdrawDelegatorRewardsMsg(msgs []sdk.Msg) error {
 	for _, msg := range msgs {
 		// authz nested message check (recursive)
 		if execMsg, ok := msg.(*authz.MsgExec); ok {
 			msgs, err := execMsg.GetMessages()
 			if err != nil {
-				return true
+				return err
 			}
 
-			if mdwr.hasWithdrawDelegatorRewardsMsg(msgs) {
-				return true
+			err = mdwr.hasWithdrawDelegatorRewardsMsg(msgs)
+			if err != nil {
+				return err
 			}
 		}
 
 		if _, ok := msg.(*distrtypes.MsgWithdrawDelegatorReward); ok {
-			return true
+			return poa.ErrWithdrawDelegatorRewardsNotAllowed
 		}
 	}
-	return false
+	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrStakingActionNotAllowed            = sdkerrors.Register(ModuleName, 1, "staking actions are now allowed on this chain")
+	ErrStakingActionNotAllowed            = sdkerrors.Register(ModuleName, 1, "staking actions are not allowed on this chain")
 	ErrPowerBelowMinimum                  = sdkerrors.Register(ModuleName, 2, "power must be above 1_000_000")
 	ErrNotAnAuthority                     = sdkerrors.Register(ModuleName, 3, "not an authority")
 	ErrUnsafePower                        = sdkerrors.Register(ModuleName, 4, "unsafe: msg.Power is >=30% of total power, set unsafe=true to override")


### PR DESCRIPTION
This PR adds unit tests for nested `authz` msg. This PR also refactors how errors from ante handler are propagated and fix a typo in one error message.