### PR TITLE
refactor: poa fixes, tweaks, and chores

### DIFF
--- a/ante/ante_test.go
+++ b/ante/ante_test.go
@@ -253,7 +253,7 @@ func TestAnteStakingFilter(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("fail: staking action not allowed after gentx (%s)", k), func(t *testing.T) {
-			for h := uint64(2); h < 10; h++ {
+			for h := int64(2); h < 10; h++ {
 				ctx = setBlockHeader(ctx, h)
 				_, err := sf.AnteHandle(ctx, tx, false, EmptyAnte)
 				require.Error(t, err)
@@ -284,7 +284,7 @@ func TestAnteDisableWithdrawRewards(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("fail: withdraw rewards not allowed after gentx (%s)", k), func(t *testing.T) {
-			for h := uint64(2); h < 10; h++ {
+			for h := int64(2); h < 10; h++ {
 				ctx = setBlockHeader(ctx, h)
 				_, err := dwr.AnteHandle(ctx, tx, false, EmptyAnte)
 				require.Error(t, err)
@@ -293,9 +293,9 @@ func TestAnteDisableWithdrawRewards(t *testing.T) {
 	}
 }
 
-func setBlockHeader(ctx sdk.Context, height uint64) sdk.Context {
+func setBlockHeader(ctx sdk.Context, height int64) sdk.Context {
 	h := ctx.BlockHeader()
-	h.Height = int64(height)
+	h.Height = height
 
 	return ctx.WithBlockHeader(h)
 }

--- a/ante/ante_test.go
+++ b/ante/ante_test.go
@@ -122,6 +122,12 @@ func TestAnteNested(t *testing.T) {
 	ctx := sdk.Context{}
 	ctx = setBlockHeader(ctx, 2)
 
+	t.Run("fail: floor > ceil on create panic", func(t *testing.T) {
+		require.Panics(t, func() {
+			NewCommissionLimitDecorator(true, math.LegacyMustNewDecFromStr("0.50"), math.LegacyMustNewDecFromStr("0.10"))
+		})
+	})
+
 	const invalidRequestErr = "messages contains *types.Any which is not a sdk.MsgRequest"
 	cases := []struct {
 		name      string

--- a/ante/commission_limit.go
+++ b/ante/commission_limit.go
@@ -24,6 +24,10 @@ type CommissionLimitDecorator struct {
 }
 
 func NewCommissionLimitDecorator(doGenTxRateValidation bool, rateFloor, rateCiel math.LegacyDec) CommissionLimitDecorator {
+	if rateFloor.GT(rateCiel) {
+		panic(fmt.Sprintf("NewCommissionLimitDecorator: rateFloor %v is greater than rateCiel %v", rateFloor, rateCiel))
+	}
+
 	return CommissionLimitDecorator{
 		DoGenTxRateValidation: doGenTxRateValidation,
 		RateFloor:             rateFloor,

--- a/errors.go
+++ b/errors.go
@@ -10,4 +10,5 @@ var (
 	ErrNotAnAuthority                     = sdkerrors.Register(ModuleName, 3, "not an authority")
 	ErrUnsafePower                        = sdkerrors.Register(ModuleName, 4, "unsafe: msg.Power is >30%% of total power, set unsafe=true to override")
 	ErrWithdrawDelegatorRewardsNotAllowed = sdkerrors.Register(ModuleName, 5, "withdraw delegator rewards is not allowed on this chain")
+	ErrValidatorAlreadyPending            = sdkerrors.Register(ModuleName, 6, "this validator is already pending")
 )

--- a/keeper/expected_keepers.go
+++ b/keeper/expected_keepers.go
@@ -52,6 +52,7 @@ type StakingKeeper interface {
 	MinCommissionRate(ctx context.Context) (math.LegacyDec, error)
 	GetValidatorByConsAddr(ctx context.Context, consAddr sdk.ConsAddress) (validator stakingtypes.Validator, err error)
 	SetParams(ctx context.Context, params stakingtypes.Params) error
+	GetParams(ctx context.Context) (stakingtypes.Params, error)
 	GetAllDelegations(ctx context.Context) (delegations []stakingtypes.Delegation, err error)
 	BondDenom(ctx context.Context) (string, error)
 	ValidatorAddressCodec() addresscodec.Codec

--- a/keeper/genesis.go
+++ b/keeper/genesis.go
@@ -2,12 +2,21 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/strangelove-ventures/poa"
 )
 
 // InitGenesis initializes the module's state from a genesis state.
 func (k *Keeper) InitGenesis(ctx context.Context, data *poa.GenesisState) error {
+	found := make(map[string]bool)
+	for _, vals := range data.Vals {
+		if found[vals.OperatorAddress] {
+			return fmt.Errorf("duplicate validator found in genesis state: %s", vals.OperatorAddress)
+		}
+		found[vals.OperatorAddress] = true
+	}
+
 	if err := k.PendingValidators.Set(ctx, poa.Validators{
 		Validators: data.Vals,
 	}); err != nil {

--- a/keeper/genesis_test.go
+++ b/keeper/genesis_test.go
@@ -23,6 +23,18 @@ func TestInitGenesis(t *testing.T) {
 		require.NoError(err)
 	})
 
+	t.Run("duplicate validators found in state", func(t *testing.T) {
+		data := &poa.GenesisState{
+			Vals: []poa.Validator{{
+				OperatorAddress: "cosmos1abc",
+			}, {
+				OperatorAddress: "cosmos1abc",
+			}},
+		}
+		err := fixture.k.InitGenesis(fixture.ctx, data)
+		require.Error(err)
+	})
+
 	t.Run("pending validator export", func(t *testing.T) {
 		acc := GenAcc()
 		valAddr := sdk.ValAddress(acc.addr)

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -221,7 +221,7 @@ func (f *testFixture) createBaseStakingValidators(t *testing.T, baseValShares in
 			fmt.Sprintf("val-%d", idx),
 			valAddr,
 			pubKey,
-			bondCoin.Amount.Int64(),
+			bondCoin.Amount.Uint64(),
 		))
 
 		if err := f.k.AddPendingValidator(f.ctx, val, pubKey); err != nil {
@@ -277,7 +277,7 @@ func (f *testFixture) createBaseStakingValidators(t *testing.T, baseValShares in
 	}
 }
 
-func CreateNewValidator(moniker string, opAddr string, pubKey cryptotypes.PubKey, amt int64) poa.Validator {
+func CreateNewValidator(moniker string, opAddr string, pubKey cryptotypes.PubKey, amt uint64) poa.Validator {
 	var pkAny *codectypes.Any
 	if pubKey != nil {
 		var err error
@@ -286,13 +286,15 @@ func CreateNewValidator(moniker string, opAddr string, pubKey cryptotypes.PubKey
 		}
 	}
 
+	sdkIntAmt := sdkmath.NewIntFromUint64(amt)
+
 	return poa.Validator{
 		OperatorAddress: opAddr,
 		ConsensusPubkey: pkAny,
 		Jailed:          false,
 		Status:          poa.Bonded,
-		Tokens:          sdkmath.NewInt(amt),
-		DelegatorShares: sdkmath.LegacyNewDecFromInt(sdkmath.NewInt(amt)),
+		Tokens:          sdkIntAmt,
+		DelegatorShares: sdkmath.LegacyNewDecFromInt(sdkIntAmt),
 		Description:     poa.NewDescription(moniker, "", "", "", ""),
 		UnbondingHeight: 0,
 		UnbondingTime:   time.Time{},
@@ -313,7 +315,7 @@ func (f *testFixture) CreatePendingValidator(name string, power uint64) sdk.ValA
 		name,
 		valAddr.String(),
 		val.valKey.PubKey(),
-		int64(power),
+		power,
 	))
 
 	if err := f.k.AddPendingValidator(f.ctx, v, val.valKey.PubKey()); err != nil {

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -242,5 +242,9 @@ func (ms msgServer) UpdateStakingParams(ctx context.Context, msg *poa.MsgUpdateS
 		MinCommissionRate: msg.Params.MinCommissionRate,
 	}
 
+	if err := stakingParams.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &poa.MsgUpdateStakingParamsResponse{}, ms.k.stakingKeeper.SetParams(ctx, stakingParams)
 }

--- a/keeper/msg_server.go
+++ b/keeper/msg_server.go
@@ -45,7 +45,7 @@ func (ms msgServer) SetPower(ctx context.Context, msg *poa.MsgSetPower) (*poa.Ms
 	}
 
 	// Sets the new POA power to the validator.
-	if _, err := ms.k.SetPOAPower(ctx, msg.ValidatorAddress, int64(msg.Power)); err != nil {
+	if _, err := ms.k.SetPOAPower(ctx, msg.ValidatorAddress, msg.Power); err != nil {
 		return nil, err
 	}
 

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -261,12 +261,12 @@ func TestRemoveValidator(t *testing.T) {
 	require.NoError(err)
 
 	for _, v := range vals {
-		power := 10_000_000
+		var power uint64 = 10_000_000
 
 		_, err = f.msgServer.SetPower(f.ctx, &poa.MsgSetPower{
 			Sender:           f.addrs[0].String(),
 			ValidatorAddress: v.OperatorAddress,
-			Power:            uint64(power),
+			Power:            power,
 			Unsafe:           true,
 		})
 		require.NoError(err)

--- a/keeper/pending.go
+++ b/keeper/pending.go
@@ -32,6 +32,12 @@ func (k Keeper) AddPendingValidator(ctx context.Context, newVal stakingtypes.Val
 		return err
 	}
 
+	for _, val := range vals.Validators {
+		if val.OperatorAddress == poaVal.OperatorAddress {
+			return poa.ErrValidatorAlreadyPending
+		}
+	}
+
 	vals.Validators = append(vals.Validators, poaVal)
 
 	return k.PendingValidators.Set(ctx, vals)

--- a/keeper/pending_test.go
+++ b/keeper/pending_test.go
@@ -20,7 +20,7 @@ func TestAddPending(t *testing.T) {
 		"myval",
 		valAddr.String(),
 		val.valKey.PubKey(),
-		int64(1_000_000),
+		1_000_000,
 	))
 
 	// successful add

--- a/keeper/pending_test.go
+++ b/keeper/pending_test.go
@@ -1,0 +1,40 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/strangelove-ventures/poa"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddPending(t *testing.T) {
+	f := SetupTest(t, 2_000_000)
+	require := require.New(t)
+
+	val := GenAcc()
+	valAddr := sdk.ValAddress(val.addr)
+	v := poa.ConvertPOAToStaking(CreateNewValidator(
+		"myval",
+		valAddr.String(),
+		val.valKey.PubKey(),
+		int64(1_000_000),
+	))
+
+	// successful add
+	err := f.k.AddPendingValidator(f.ctx, v, val.valKey.PubKey())
+	require.NoError(err)
+
+	// duplicate (fails)
+	err = f.k.AddPendingValidator(f.ctx, v, val.valKey.PubKey())
+	require.Error(err)
+	require.Equal(poa.ErrValidatorAlreadyPending, err)
+
+	// remove pending
+	err = f.k.RemovePendingValidator(f.ctx, v.OperatorAddress)
+	require.NoError(err)
+
+	pending, err := f.k.GetPendingValidators(f.ctx)
+	require.NoError(err)
+	require.Len(pending.Validators, 0)
+}

--- a/keeper/pending_test.go
+++ b/keeper/pending_test.go
@@ -3,9 +3,11 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/strangelove-ventures/poa"
 	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/strangelove-ventures/poa"
 )
 
 func TestAddPending(t *testing.T) {
@@ -36,5 +38,5 @@ func TestAddPending(t *testing.T) {
 
 	pending, err := f.k.GetPendingValidators(f.ctx)
 	require.NoError(err)
-	require.Len(pending.Validators, 0)
+	require.Empty(pending.Validators)
 }

--- a/simulation/operations.go
+++ b/simulation/operations.go
@@ -1,7 +1,6 @@
 package simulation
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"os"
@@ -126,8 +125,6 @@ func SimulateMsgCreateValidator(txGen client.TxConfig, k keeper.Keeper) simtypes
 		}
 		for _, v := range vals.Validators {
 			if v.OperatorAddress == address.String() {
-				fmt.Println(v.OperatorAddress, address.String())
-				fmt.Println("skipping due to validator already being in PendingValidators")
 				return simtypes.OperationMsg{}, nil, nil
 			}
 		}

--- a/simulation/operations.go
+++ b/simulation/operations.go
@@ -122,7 +122,7 @@ func SimulateMsgCreateValidator(txGen client.TxConfig, k keeper.Keeper) simtypes
 
 		vals, err := k.PendingValidators.Get(ctx)
 		if err != nil {
-			return simtypes.OperationMsg{}, nil, nil
+			return simtypes.OperationMsg{}, nil, nil // nolint:nilerr
 		}
 		for _, v := range vals.Validators {
 			if v.OperatorAddress == address.String() {

--- a/simulation/operations.go
+++ b/simulation/operations.go
@@ -1,6 +1,7 @@
 package simulation
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"os"
@@ -118,6 +119,18 @@ func SimulateMsgCreateValidator(txGen client.TxConfig, k keeper.Keeper) simtypes
 		selfDelegation := sdk.NewCoin(denom, amount)
 		description := generateRandomDescription(r)
 		commission := generateRandomCommission(r)
+
+		vals, err := k.PendingValidators.Get(ctx)
+		if err != nil {
+			return simtypes.OperationMsg{}, nil, nil
+		}
+		for _, v := range vals.Validators {
+			if v.OperatorAddress == address.String() {
+				fmt.Println(v.OperatorAddress, address.String())
+				fmt.Println("skipping due to validator already being in PendingValidators")
+				return simtypes.OperationMsg{}, nil, nil
+			}
+		}
 
 		msg, err := poatypes.NewMsgCreateValidator(address.String(), simAccount.ConsKey.PubKey(), description, commission, selfDelegation.Amount)
 		if err != nil {


### PR DESCRIPTION
- Also migrates all int64 -> uint64 to just a sdkmath.NewIntFromUint64(uint64) consumer, rather than type converting. Makes linter happy :)